### PR TITLE
Add personalized site metadata configuration

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,34 +13,41 @@ import { authOptions } from '@/lib/auth'
 import { getIconUrls } from '@/lib/githubApi'
 import { getServerSession } from 'next-auth/next'
 import { gowun_wodum } from '@/components/ui/font'
+import { getSiteConfig } from '@/lib/siteConfig'
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations('metadata')
   const session = await getServerSession(authOptions)
+  const siteConfig = getSiteConfig()
 
-  const title =
-    t('title') || 'Cofe - Write and sync your blog posts & memos with one-click GitHub sign-in'
-  const description =
-    t('description') ||
-    'Write and preserve your blogs, memos, and notes effortlessly. Sign in with GitHub to automatically sync your content to your own repository, ensuring your ideas are safely stored as long as GitHub exists.'
+  const title = t('title') || siteConfig.title
+  const description = t('description') || siteConfig.description
 
   const { iconPath } = await getIconPaths(session?.accessToken)
 
   return {
     title,
     description,
+    keywords: siteConfig.keywords,
+    authors: [{ name: siteConfig.author.name }],
+    creator: siteConfig.author.name,
+    publisher: siteConfig.author.name,
     manifest: '/manifest.json',
     openGraph: {
       title,
       description,
       images: [{ url: iconPath, width: 512, height: 512, alt: 'App Logo' }],
       type: 'website',
+      siteName: siteConfig.title,
+      locale: 'en_US',
     },
     twitter: {
       card: 'summary_large_image',
       title,
       description,
       images: [iconPath],
+      creator: `@${siteConfig.social.twitter}`,
+      site: `@${siteConfig.social.twitter}`,
     },
   }
 }

--- a/data/site-config.json
+++ b/data/site-config.json
@@ -1,0 +1,14 @@
+{
+  "title": "Minghe's Blog",
+  "description": "Minghe's personal blog sharing travel experiences across Europe and Asia, tech insights, and daily thoughts. Built with GitHub-powered markdown writing.",
+  "author": {
+    "name": "Minghe",
+    "bio": "Software engineer and travel enthusiast sharing experiences from around the world",
+    "location": "Europe/Asia"
+  },
+  "keywords": ["travel", "tech", "blog", "europe", "asia", "software", "programming"],
+  "social": {
+    "github": "metrue",
+    "twitter": "_metrue"
+  }
+}

--- a/lib/siteConfig.ts
+++ b/lib/siteConfig.ts
@@ -1,0 +1,20 @@
+import siteConfig from '@/data/site-config.json'
+
+export interface SiteConfig {
+  title: string
+  description: string
+  author: {
+    name: string
+    bio: string
+    location: string
+  }
+  keywords: string[]
+  social: {
+    github: string
+    twitter: string
+  }
+}
+
+export function getSiteConfig(): SiteConfig {
+  return siteConfig
+}


### PR DESCRIPTION
- Create data/site-config.json for centralized site metadata
- Add lib/siteConfig.ts utility with TypeScript types
- Update layout.tsx to use personalized title, description, keywords, author info, and social handles
- Enhance SEO with proper meta tags, OpenGraph, and Twitter card data
- Replace generic descriptions with personal blog content focus

This improves Google search appearance and social media previews with content about travel experiences, tech insights, and personal thoughts.

🤖 Generated with [Claude Code](https://claude.ai/code)