### PR TITLE
Enforce site config for title and description metadata

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,6 @@
 import './globals.css'
 
-import { getLocale, getMessages, getTranslations } from 'next-intl/server'
+import { getLocale, getMessages } from 'next-intl/server'
 
 import CreateButton from '@/components/CreateButton'
 import Head from 'next/head'
@@ -16,7 +16,6 @@ import { gowun_wodum } from '@/components/ui/font'
 import { getSiteConfig } from '@/lib/siteConfig'
 
 export async function generateMetadata(): Promise<Metadata> {
-  const t = await getTranslations('metadata')
   const session = await getServerSession(authOptions)
   const siteConfig = getSiteConfig()
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -20,8 +20,8 @@ export async function generateMetadata(): Promise<Metadata> {
   const session = await getServerSession(authOptions)
   const siteConfig = getSiteConfig()
 
-  const title = t('title') || siteConfig.title
-  const description = t('description') || siteConfig.description
+  const title = siteConfig.title
+  const description = siteConfig.description
 
   const { iconPath } = await getIconPaths(session?.accessToken)
 


### PR DESCRIPTION
- Remove i18n fallback for title and description in layout.tsx
- Use site config values directly for consistent branding
- Ensures metadata always reflects values from data/site-config.json

🤖 Generated with [Claude Code](https://claude.ai/code)