### PR TITLE
fix: add markdown rendering to StatusCard for proper image display

### DIFF
--- a/components/StatusCard.tsx
+++ b/components/StatusCard.tsx
@@ -5,6 +5,8 @@ import Image from 'next/image'
 import Link from 'next/link'
 import { Memo } from '@/lib/types'
 import { getRelativeTimeString } from '@/lib/utils'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
 
 const SocialLink = ({ href, title, icon, label, textClassName = '' }: {
   href: string
@@ -119,7 +121,34 @@ export const StatusCard = ({
                 more
               </Link>
             </div>
-            <p className='text-base leading-relaxed break-words'>{memo && memo.content}</p>
+            {memo && (
+              <div className='text-base leading-relaxed break-words prose prose-sm max-w-none'>
+                <ReactMarkdown
+                  remarkPlugins={[remarkGfm]}
+                  components={{
+                    img: ({ src, alt }) => (
+                      <img
+                        src={src}
+                        alt={alt || ''}
+                        className='max-w-full h-auto rounded'
+                      />
+                    ),
+                    a: ({ children, ...props }) => (
+                      <a
+                        {...props}
+                        className='text-gray-400 no-underline hover:text-gray-600 hover:underline hover:underline-offset-4 transition-colors duration-200'
+                        target='_blank'
+                        rel='noopener noreferrer'
+                      >
+                        {children}
+                      </a>
+                    ),
+                  }}
+                >
+                  {memo.content}
+                </ReactMarkdown>
+              </div>
+            )}
           </div>
         </CardContent>
       </Card>


### PR DESCRIPTION
Fixes issue #31 where images in memos were showing as raw markdown syntax on the main page. The StatusCard component now uses ReactMarkdown with remarkGfm plugin to properly render images and other markdown content, matching the behavior of the MemoCard component in the "more" view.
