### PR TITLE
fix: Remove authentication requirement for public read operations

### DIFF
--- a/app/blog/[id]/page.tsx
+++ b/app/blog/[id]/page.tsx
@@ -1,14 +1,12 @@
 import { PostContainer } from './component'
-import { getServerSession } from 'next-auth/next'
-import { authOptions } from '@/lib/auth'
 import { createSmartClient } from '@/lib/smartClient'
 import BlogDiscussions from '@/components/BlogDiscussions'
 
 export const revalidate = process.env.NODE_ENV === 'development' ? 0 : 60;
 
 export default async function Page({ params }: { params: { id: string } }) {
-  const session = await getServerSession(authOptions)
-  const client = createSmartClient(session?.accessToken)
+  // No authentication needed for viewing blog posts
+  const client = createSmartClient()
   const posts = await client.getBlogPosts()
   const post = posts.find((p) => p.id === decodeURIComponent(params.id))
 

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,14 +1,11 @@
 import BlogList from "@/components/BlogList";
-import { authOptions } from "@/lib/auth";
 import { createSmartClient } from '@/lib/smartClient'
-import { getServerSession } from "next-auth/next";
 
 export const revalidate = process.env.NODE_ENV === 'development' ? 0 : 60;
 
 export default async function BlogPage() {
-  const session = await getServerSession(authOptions);
-
-  const client = createSmartClient(session?.accessToken);
+  // No authentication needed for viewing blog posts
+  const client = createSmartClient();
 
   try {
     const posts = await client.getBlogPosts();


### PR DESCRIPTION
## Summary
Makes the blog completely public for reading - no authentication required to view content. Authentication is only required for mutations (create/edit/delete).

## Problem
Users were getting "Bad credentials" errors when:
- Their GitHub token expired
- They had corrupted auth state in browser cache
- They weren't logged in at all

This blocked them from viewing public blog content, which should always be accessible.

## Solution
- Removed authentication from blog list page (`/blog`)
- Removed authentication from blog detail pages (`/blog/[id]`)
- Memos page was already public
- GraphQL queries already didn't require auth
- Mutations still require authentication (unchanged)

## Testing
- ✅ Blog pages load without login
- ✅ Memo pages load without login  
- ✅ Creating/editing still requires login
- ✅ No more "Bad credentials" errors for visitors
- ✅ Lint and TypeScript checks pass

## Impact
The site is now truly public for reading - anyone can view blog posts and memos without authentication. This is the expected behavior for a public blog.

🤖 Generated with [Claude Code](https://claude.ai/code)