### PR TITLE
feat: Display high-quality full-size images in blog posts

### DIFF
--- a/components/BlogPostContent.tsx
+++ b/components/BlogPostContent.tsx
@@ -99,15 +99,16 @@ export function BlogPostContent({ title, date, content, slug, headerContent, dis
                 return isImageOnly ? <>{children}</> : <p>{children}</p>
               },
               img: ({ children, ...props }) => (
-                <div className='my-6 flex justify-center'>
-                  <div className='max-w-2xl w-full'>
+                <div className='my-8 flex justify-center'>
+                  <div className='w-full'>
                     <Image
                       src={props.src || ''}
                       alt={props.alt || 'image'}
-                      width={600}
-                      height={400}
-                      className='h-auto w-full object-cover rounded-lg shadow-sm'
-                      style={{ maxHeight: '400px' }}
+                      width={1200}
+                      height={800}
+                      className='h-auto w-full object-contain rounded-lg shadow-md'
+                      quality={100}
+                      priority
                     />
                     {children && <div className='text-center mt-3 text-sm text-gray-500 italic'>{children}</div>}
                   </div>


### PR DESCRIPTION
## Summary
- Enhanced image display in blog posts to showcase travel photos in their full glory
- Images now display at higher resolution with no artificial height constraints
- Matches the quality seen in list page thumbnails

## Changes
- **Resolution**: Increased from 600x400 to 1200x800 for crisp details
- **Container**: Full width display instead of restricted max-w-2xl
- **Display**: Changed from object-cover (crops) to object-contain (preserves full image)
- **Quality**: Set to maximum (100) with priority loading
- **Styling**: Enhanced shadow depth and spacing for better visual presentation

## Test Plan
- [x] Verified images display correctly in blog posts
- [x] Confirmed no TypeScript errors (`npx tsc --noEmit`)
- [x] All lint checks pass (`npm run lint`)
- [x] Tested with actual travel blog posts containing images
- [x] Verified responsive behavior on different screen sizes

## Before/After
**Before**: Images were constrained to 400px height, potentially cropped, and limited in width
**After**: Images display at full quality, complete aspect ratio preserved, using full content width

🤖 Generated with [Claude Code](https://claude.ai/code)