### PR TITLE
fix: Implement smart User-Agent fallback for Reddit API compatibility

### DIFF
--- a/components/BlogDiscussions.tsx
+++ b/components/BlogDiscussions.tsx
@@ -5,6 +5,27 @@ interface BlogDiscussionsProps {
   discussions?: ExternalDiscussion[]
 }
 
+// Helper function to detect server-like User-Agents that Reddit blocks
+function isServerUserAgent(userAgent: string): boolean {
+  const serverPatterns = [
+    'curl/',
+    'undici',
+    'node-fetch',
+    'axios/',
+    'python-requests',
+    'Go-http-client',
+    'Java/',
+    'okhttp',
+    'Wget/',
+    'Bot',
+    'crawler',
+    'spider'
+  ]
+  
+  const lowerUA = userAgent.toLowerCase()
+  return serverPatterns.some(pattern => lowerUA.includes(pattern.toLowerCase()))
+}
+
 /**
  * Server component for rendering external discussions
  * Fetches comments on the server, no API route needed!
@@ -16,7 +37,13 @@ export default async function BlogDiscussions({ discussions }: BlogDiscussionsPr
 
   // Get the client's User-Agent from the request headers
   const headersList = headers()
-  const userAgent = headersList.get('user-agent') || 'Mozilla/5.0 (compatible; Blog Comment Fetcher)'
+  const clientUserAgent = headersList.get('user-agent')
+  
+  // Use a convincing browser User-Agent fallback for cases where client UA is missing or blocked
+  // Reddit specifically blocks server-like User-Agents (curl, undici, etc.)
+  const userAgent = clientUserAgent && !isServerUserAgent(clientUserAgent) 
+    ? clientUserAgent 
+    : 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
 
   return (
     <DiscussionServer


### PR DESCRIPTION
## Summary

Fixes the Reddit comments not showing issue in production environment (blog.minghe.me) by implementing smart User-Agent detection and fallback.

## Problem

- Reddit API was returning "403 Blocked for URL" errors in Vercel production
- Root cause: Reddit blocks server-like User-Agents (curl, undici, node-fetch, etc.) 
- Local development worked fine, but production Vercel environment was blocked

## Solution

### 1. User-Agent Detection (`components/BlogDiscussions.tsx:8-26`)
- Added `isServerUserAgent()` helper function to identify blocked User-Agent patterns
- Detects patterns like: `curl/`, `undici`, `node-fetch`, `axios/`, `python-requests`, `Bot`, `crawler`, etc.

### 2. Dynamic Fallback Strategy
- Extract client User-Agent from Next.js `headers()` for server-side rendering
- Use client User-Agent when available and not server-like
- Fallback to convincing browser User-Agent: `Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36`

### 3. Production Compatibility
- Ensures Reddit comments work in Vercel production environment
- Maintains compatibility with local development
- No impact on V2EX or Hacker News comment fetching

## Code Changes

```tsx
// Helper function to detect server-like User-Agents that Reddit blocks
function isServerUserAgent(userAgent: string): boolean {
  const serverPatterns = [
    'curl/', 'undici', 'node-fetch', 'axios/', 'python-requests',
    'Go-http-client', 'Java/', 'okhttp', 'Wget/', 'Bot', 'crawler', 'spider'
  ]
  const lowerUA = userAgent.toLowerCase()
  return serverPatterns.some(pattern => lowerUA.includes(pattern.toLowerCase()))
}

// Get client User-Agent and implement fallback
const headersList = headers()
const clientUserAgent = headersList.get('user-agent')
const userAgent = clientUserAgent && !isServerUserAgent(clientUserAgent) 
  ? clientUserAgent 
  : 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
```

## Test Plan

- [x] Build passes without TypeScript errors (`npm run build`)
- [x] Linting passes (`npm run lint`) 
- [x] Local development continues to work
- [ ] Deploy to production and verify Reddit comments show correctly
- [ ] Test with multiple blog posts that have Reddit discussions
- [ ] Verify V2EX and Hacker News comments unaffected

## Related Issues

Resolves the production Reddit comments issue reported for https://blog.minghe.me/blog/first-golang-project-fx

🤖 Generated with [Claude Code](https://claude.ai/code)