### PR TITLE
Fix excessive spacing between text and images in blog posts

### DIFF
--- a/components/BlogPostContent.tsx
+++ b/components/BlogPostContent.tsx
@@ -46,7 +46,7 @@ export function BlogPostContent({ title, date, content, slug, headerContent, dis
             )}
           </div>
         </header>
-        <div className='prose prose-lg max-w-none text-gray-900 leading-relaxed'>
+        <div className='prose prose-lg max-w-none text-gray-900 leading-relaxed prose-p:my-3 prose-img:my-0'>
           <ReactMarkdown
             remarkPlugins={[remarkGfm, remarkMath]}
             rehypePlugins={[rehypeKatex]}
@@ -99,7 +99,7 @@ export function BlogPostContent({ title, date, content, slug, headerContent, dis
                 return isImageOnly ? <>{children}</> : <p>{children}</p>
               },
               img: ({ children, ...props }) => (
-                <div className='my-8 flex justify-center'>
+                <div className='flex justify-center'>
                   <div className='w-full'>
                     <Image
                       src={props.src || ''}
@@ -110,7 +110,7 @@ export function BlogPostContent({ title, date, content, slug, headerContent, dis
                       quality={100}
                       priority
                     />
-                    {children && <div className='text-center mt-3 text-sm text-gray-500 italic'>{children}</div>}
+                    {children && <div className='text-center mt-2 text-sm text-gray-500 italic'>{children}</div>}
                   </div>
                 </div>
               ),


### PR DESCRIPTION
## Summary
- Reduced excessive vertical spacing between text and images in blog post pages
- Improved visual cohesion and readability of blog content

## Problem
Blog posts had too much white space between paragraphs and images, making the content feel disconnected and reducing reading flow.

## Solution
- Removed the `my-8` (32px) margin from image wrappers
- Added Tailwind Typography prose modifiers to control spacing:
  - `prose-p:my-3` for consistent paragraph spacing
  - `prose-img:my-0` to remove default image margins
- Reduced image caption margin from `mt-3` to `mt-2`

## Testing
- [x] All tests pass (`npm test`)
- [x] TypeScript compiles without errors (`npx tsc --noEmit`)
- [x] Lint checks pass (`npm run lint`)
- [x] Visually verified improved spacing in blog posts

## Screenshots
Before: Large gaps between text and images
After: Compact, cohesive layout with appropriate spacing

🤖 Generated with [Claude Code](https://claude.ai/code)