### PR TITLE
fix: Resolve authenticated user blog access issue

### DIFF
--- a/lib/smartClient.ts
+++ b/lib/smartClient.ts
@@ -51,7 +51,7 @@ export class SmartClient {
             apiClient.getLinks(username),
           getLikes: () => 
             apiClient.getLikes(username),
-          updateLikes: (likesData: any) => 
+          updateLikes: (likesData: LikesDatabase) => 
             apiClient.updateLikes(likesData, username),
           getDrafts: () => 
             apiClient.getDrafts(username),

--- a/lib/smartClient.ts
+++ b/lib/smartClient.ts
@@ -37,7 +37,27 @@ export class SmartClient {
       }
       
       if (this.accessToken) {
-        this.githubClient = createGitHubAPIClient(this.accessToken)
+        // Create API client and wrap it to always pass the correct owner
+        const apiClient = createGitHubAPIClient(this.accessToken)
+        this.githubClient = {
+          ...apiClient,
+          getBlogPosts: (includeAuthenticatedDrafts = false) => 
+            apiClient.getBlogPosts(username, includeAuthenticatedDrafts),
+          getBlogPost: (name: string) => 
+            apiClient.getBlogPost(name, username),
+          getMemos: () => 
+            apiClient.getMemos(username),
+          getLinks: () => 
+            apiClient.getLinks(username),
+          getLikes: () => 
+            apiClient.getLikes(username),
+          updateLikes: (likesData: any) => 
+            apiClient.updateLikes(likesData, username),
+          getDrafts: () => 
+            apiClient.getDrafts(username),
+          getAllBlogPosts: () => 
+            apiClient.getAllBlogPosts(username)
+        }
       } else {
         this.githubClient = createPublicGitHubClient(username)
       }


### PR DESCRIPTION
## Summary

Fixes the production issue where logged-in users couldn't see blog posts due to incorrect owner resolution in GitHubAPIClient.

## Root Cause Analysis

**Problem**: SmartClient was creating GitHubAPIClient without passing the `owner` parameter:
```typescript
// BEFORE (broken):
this.githubClient = createGitHubAPIClient(this.accessToken)  // No username passed

// This caused GitHubAPIClient to fall back to:
const { data: user } = await octokit.users.getAuthenticated()
// Which returned: { login: "true" } instead of { login: "metrue" }

// Result: API calls to /repos/true/Cofe → 404 Not Found
```

**Why this happened**:
- Non-authenticated users: ✅ Use PublicGitHubClient (manifest-based) → works
- Authenticated users: ❌ Use GitHubAPIClient → relies on OAuth token → broken

## The Fix

SmartClient now wraps GitHubAPIClient to always pass the correct username from `GITHUB_USERNAME`:

```typescript
// AFTER (fixed):
const apiClient = createGitHubAPIClient(this.accessToken)
this.githubClient = {
  ...apiClient,
  getBlogPosts: (includeAuthenticatedDrafts = false) => 
    apiClient.getBlogPosts(username, includeAuthenticatedDrafts),  // Always pass username
  getBlogPost: (name: string) => 
    apiClient.getBlogPost(name, username),  // Always pass username
  // ... all other methods
}
```

## Changes Made

- ✅ SmartClient wraps GitHubAPIClient to inject correct owner
- ✅ All GitHubAPIClient methods now receive proper username  
- ✅ Eliminates dependency on OAuth token for owner resolution
- ✅ Consistent behavior between authenticated/non-authenticated users

## Testing

**Before fix**:
- ❌ Logged-in users: No blog posts (tries `/repos/true/Cofe`)
- ✅ Non-logged users: Shows blog posts correctly

**After fix**:
- ✅ Logged-in users: Should show blog posts correctly
- ✅ Non-logged users: Continue to work as before

## Verification Steps

1. [ ] Deploy this fix
2. [ ] Test logged-in user can see blog posts
3. [ ] Test non-logged user still works
4. [ ] Check production logs show correct repository access

🤖 Generated with [Claude Code](https://claude.ai/code)