### PR TITLE
perf: use getBlogPost(id) directly in blog detail page

### DIFF
--- a/app/blog/[id]/page.tsx
+++ b/app/blog/[id]/page.tsx
@@ -1,16 +1,15 @@
 import { PostContainer } from './component'
-import { createSmartClient } from '@/lib/smartClient'
-import BlogDiscussions from '@/components/BlogDiscussions'
 import { getServerSession } from 'next-auth/next'
 import { authOptions } from '@/lib/auth'
+import { createSmartClient } from '@/lib/smartClient'
+import BlogDiscussions from '@/components/BlogDiscussions'
 
 export const revalidate = process.env.NODE_ENV === 'development' ? 0 : 60;
 
 export default async function Page({ params }: { params: { id: string } }) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerSession(authOptions)
   const client = createSmartClient(session?.accessToken)
-  const posts = await client.getBlogPosts()
-  const post = posts.find((p) => p.id === decodeURIComponent(params.id))
+  const post = await client.getBlogPost(decodeURIComponent(params.id) + '.md')
 
   if (!post) {
     return <div>Post not found</div>


### PR DESCRIPTION
Fixes N+1 API calls: previously fetched ALL posts then did .find(). Now calls getBlogPost(id) directly.