### PR TITLE
feat(highlights): inline select-to-comment on blog posts

### DIFF
--- a/__tests__/lib/highlights/anchoring.test.ts
+++ b/__tests__/lib/highlights/anchoring.test.ts
@@ -1,0 +1,285 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import {
+  rangeToAnchor,
+  anchorToRange,
+} from '@/lib/highlights/anchoring'
+import { HighlightAnchorSchema } from '@/lib/highlights/schema'
+
+function makeArticle(html: string): HTMLElement {
+  const article = document.createElement('article')
+  article.innerHTML = html
+  document.body.appendChild(article)
+  return article
+}
+
+function cleanup() {
+  document.body.innerHTML = ''
+}
+
+/**
+ * Construct a Range covering [start, end) char offsets within `el.textContent`.
+ * Used only as a test helper — not part of the public anchoring API.
+ */
+function rangeForChars(el: HTMLElement, start: number, end: number): Range {
+  const range = document.createRange()
+  let cursor = 0
+  let startSet = false
+  const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT)
+  let node: Node | null = walker.nextNode()
+  while (node) {
+    const len = node.textContent?.length ?? 0
+    if (!startSet && start >= cursor && start <= cursor + len) {
+      range.setStart(node, start - cursor)
+      startSet = true
+    }
+    if (end >= cursor && end <= cursor + len) {
+      range.setEnd(node, end - cursor)
+      return range
+    }
+    cursor += len
+    node = walker.nextNode()
+  }
+  throw new Error(`Could not build range for [${start}, ${end}) in element of length ${cursor}`)
+}
+
+describe('lib/highlights/anchoring', () => {
+  afterEach(cleanup)
+
+  describe('rangeToAnchor', () => {
+    it('happy path: single text node, returns offsets + capped prefix/suffix', () => {
+      const article = makeArticle('<p>Hello world from blog.minghe.me today</p>')
+      // textContent = "Hello world from blog.minghe.me today" (37 chars)
+      const range = rangeForChars(article, 6, 11) // "world"
+
+      const anchor = rangeToAnchor(range, article)
+
+      expect(anchor).not.toBeNull()
+      expect(anchor!.exact).toBe('world')
+      expect(anchor!.startOffset).toBe(6)
+      expect(anchor!.endOffset).toBe(11)
+      expect(anchor!.prefix).toBe('Hello ')
+      expect(anchor!.suffix).toBe(' from blog.minghe.me today')
+
+      // Anchor must validate against the schema
+      expect(() => HighlightAnchorSchema.parse(anchor)).not.toThrow()
+    })
+
+    it('caps prefix and suffix at 32 chars even for long surrounding text', () => {
+      const before = 'a'.repeat(100)
+      const after = 'b'.repeat(100)
+      const article = makeArticle(`<p>${before}TARGET${after}</p>`)
+      const range = rangeForChars(article, 100, 106) // "TARGET"
+
+      const anchor = rangeToAnchor(range, article)!
+
+      expect(anchor.prefix).toHaveLength(32)
+      expect(anchor.suffix).toHaveLength(32)
+      expect(anchor.prefix).toBe('a'.repeat(32))
+      expect(anchor.suffix).toBe('b'.repeat(32))
+    })
+
+    it('handles range starting at offset 0 (empty prefix)', () => {
+      const article = makeArticle('<p>Hello world</p>')
+      const range = rangeForChars(article, 0, 5) // "Hello"
+
+      const anchor = rangeToAnchor(range, article)!
+
+      expect(anchor.exact).toBe('Hello')
+      expect(anchor.prefix).toBe('')
+      expect(anchor.suffix).toBe(' world')
+    })
+
+    it('handles range ending at end of article (empty suffix)', () => {
+      const article = makeArticle('<p>Hello world</p>')
+      const range = rangeForChars(article, 6, 11) // "world"
+
+      const anchor = rangeToAnchor(range, article)!
+
+      expect(anchor.exact).toBe('world')
+      expect(anchor.suffix).toBe('')
+    })
+
+    it('handles range spanning multiple text nodes (across <strong>)', () => {
+      const article = makeArticle('<p>Click <strong>here</strong> now please</p>')
+      // textContent = "Click here now please" (21 chars)
+      const range = rangeForChars(article, 4, 11) // "k here " across text→strong→text
+
+      const anchor = rangeToAnchor(range, article)!
+
+      expect(anchor.exact).toBe('k here ')
+      expect(anchor.startOffset).toBe(4)
+      expect(anchor.endOffset).toBe(11)
+    })
+
+    it('returns null for a range outside the article element', () => {
+      const article = makeArticle('<p>inside</p>')
+      const outside = document.createElement('div')
+      outside.textContent = 'outside text'
+      document.body.appendChild(outside)
+
+      const range = document.createRange()
+      range.setStart(outside.firstChild!, 0)
+      range.setEnd(outside.firstChild!, 7) // "outside"
+
+      const anchor = rangeToAnchor(range, article)
+
+      expect(anchor).toBeNull()
+    })
+
+    it('returns null for a collapsed (zero-length) range', () => {
+      const article = makeArticle('<p>Hello world</p>')
+      const range = rangeForChars(article, 5, 5) // empty
+
+      const anchor = rangeToAnchor(range, article)
+
+      expect(anchor).toBeNull()
+    })
+  })
+
+  describe('anchorToRange — fast path (offsets match)', () => {
+    it('roundtrips single-node selection', () => {
+      const article = makeArticle('<p>Hello world from blog</p>')
+      const range = rangeForChars(article, 6, 11)
+      const anchor = rangeToAnchor(range, article)!
+
+      const restored = anchorToRange(anchor, article)
+
+      expect(restored).not.toBeNull()
+      expect(restored!.toString()).toBe('world')
+    })
+
+    it('roundtrips multi-node selection (across <strong>)', () => {
+      const article = makeArticle('<p>The <strong>quick</strong> brown fox</p>')
+      const range = rangeForChars(article, 0, 9) // "The quick"
+      const anchor = rangeToAnchor(range, article)!
+
+      const restored = anchorToRange(anchor, article)!
+
+      expect(restored.toString()).toBe('The quick')
+    })
+
+    it('roundtrips across multiple paragraphs', () => {
+      const article = makeArticle('<p>First paragraph.</p><p>Second paragraph.</p>')
+      // textContent = "First paragraph.Second paragraph." (33 chars; no whitespace between blocks)
+      const range = rangeForChars(article, 6, 25) // "paragraph.Second pa"
+      const anchor = rangeToAnchor(range, article)!
+
+      const restored = anchorToRange(anchor, article)!
+
+      expect(restored.toString()).toBe('paragraph.Second pa')
+    })
+  })
+
+  describe('anchorToRange — resilient path (prefix + exact + suffix)', () => {
+    it('finds the highlight after content was inserted before it (offsets shifted)', () => {
+      const original = makeArticle('<p>Hello world from blog.minghe.me</p>')
+      const range = rangeForChars(original, 6, 11) // "world"
+      const anchor = rangeToAnchor(range, original)!
+
+      // Reader edits the post — adds an intro paragraph
+      const edited = makeArticle('<p>NEW INTRO. Hello world from blog.minghe.me</p>')
+
+      const restored = anchorToRange(anchor, edited)!
+
+      expect(restored.toString()).toBe('world')
+      // And it picked the RIGHT "world" (only one occurrence here, but offsets are stale)
+    })
+
+    it('disambiguates between two identical "exact" strings using prefix/suffix', () => {
+      // textContent = "The cat sat on the mat. The cat ran away."
+      const article = makeArticle('<p>The cat sat on the mat. The cat ran away.</p>')
+      const firstCatRange = rangeForChars(article, 4, 7) // first "cat"
+      const secondCatRange = rangeForChars(article, 28, 31) // second "cat"
+
+      const firstAnchor = rangeToAnchor(firstCatRange, article)!
+      const secondAnchor = rangeToAnchor(secondCatRange, article)!
+
+      // Restore both — they should land on different occurrences
+      const firstRestored = anchorToRange(firstAnchor, article)!
+      const secondRestored = anchorToRange(secondAnchor, article)!
+
+      // Compare by start offset within the article
+      const articleText = article.textContent!
+      const firstStart = articleText.indexOf(firstRestored.toString(), 0)
+      // Crude but works: the first restored range should start at offset 4 (first "cat")
+      // and the second at offset 28
+      expect(firstAnchor.startOffset).toBe(4)
+      expect(secondAnchor.startOffset).toBe(28)
+      expect(firstRestored.toString()).toBe('cat')
+      expect(secondRestored.toString()).toBe('cat')
+
+      // Now mutate offsets so fast path misses, force resilient path
+      const editedArticle = makeArticle('<p>NEW: The cat sat on the mat. The cat ran away.</p>')
+      const firstRestoredEdited = anchorToRange(firstAnchor, editedArticle)!
+      const secondRestoredEdited = anchorToRange(secondAnchor, editedArticle)!
+
+      // First "cat" in edited article is at offset 9; second at 33.
+      const editedText = editedArticle.textContent!
+      const firstResolvedStart = computeRangeStart(firstRestoredEdited, editedArticle)
+      const secondResolvedStart = computeRangeStart(secondRestoredEdited, editedArticle)
+      expect(editedText.slice(firstResolvedStart, firstResolvedStart + 3)).toBe('cat')
+      expect(editedText.slice(secondResolvedStart, secondResolvedStart + 3)).toBe('cat')
+      expect(firstResolvedStart).not.toBe(secondResolvedStart)
+      expect(firstResolvedStart).toBeLessThan(secondResolvedStart)
+    })
+  })
+
+  describe('anchorToRange — last-resort path (exact only)', () => {
+    it('still finds a unique exact match when prefix+suffix fail to combine', () => {
+      const original = makeArticle('<p>Look at this UNIQUEPHRASE in the text</p>')
+      const range = rangeForChars(original, 13, 25) // "UNIQUEPHRASE" (12 chars)
+      const anchor = rangeToAnchor(range, original)!
+
+      // Heavy edit — surrounding context is gone, only the unique phrase remains
+      const edited = makeArticle('<p>Totally different. UNIQUEPHRASE. Different again.</p>')
+
+      const restored = anchorToRange(anchor, edited)
+
+      expect(restored).not.toBeNull()
+      expect(restored!.toString()).toBe('UNIQUEPHRASE')
+    })
+  })
+
+  describe('anchorToRange — orphan detection', () => {
+    it('returns null when exact text is gone entirely', () => {
+      const original = makeArticle('<p>Hello DELETEME world</p>')
+      const range = rangeForChars(original, 6, 14) // "DELETEME"
+      const anchor = rangeToAnchor(range, original)!
+
+      const edited = makeArticle('<p>Hello world</p>')
+
+      const restored = anchorToRange(anchor, edited)
+
+      expect(restored).toBeNull()
+    })
+
+    it('returns null for empty article', () => {
+      const article = makeArticle('')
+      const anchor = {
+        startOffset: 0,
+        endOffset: 5,
+        exact: 'hello',
+        prefix: '',
+        suffix: '',
+      }
+
+      const restored = anchorToRange(anchor, article)
+
+      expect(restored).toBeNull()
+    })
+  })
+})
+
+/**
+ * Helper: compute the starting char offset of `range` within
+ * `root.textContent`. Used to assert WHICH occurrence got picked.
+ */
+function computeRangeStart(range: Range, root: HTMLElement): number {
+  const pre = document.createRange()
+  pre.selectNodeContents(root)
+  pre.setEnd(range.startContainer, range.startOffset)
+  return pre.toString().length
+}

--- a/__tests__/lib/highlights/cardLayout.test.ts
+++ b/__tests__/lib/highlights/cardLayout.test.ts
@@ -1,0 +1,63 @@
+/**
+ * @jest-environment node
+ */
+
+import { solveCardLayout, CardSpec } from '@/lib/highlights/cardLayout'
+
+describe('solveCardLayout', () => {
+  it('keeps non-overlapping cards at their desired tops', () => {
+    const specs: CardSpec[] = [
+      { id: 'a', desiredTop: 0, height: 50 },
+      { id: 'b', desiredTop: 100, height: 50 },
+      { id: 'c', desiredTop: 200, height: 50 },
+    ]
+    const tops = solveCardLayout(specs)
+    expect(tops.get('a')).toBe(0)
+    expect(tops.get('b')).toBe(100)
+    expect(tops.get('c')).toBe(200)
+  })
+
+  it('pushes overlapping cards down by stacking with gap', () => {
+    const specs: CardSpec[] = [
+      { id: 'a', desiredTop: 0, height: 100 },
+      { id: 'b', desiredTop: 50, height: 50 }, // wants 50, but a goes to 100
+    ]
+    const tops = solveCardLayout(specs, 8)
+    expect(tops.get('a')).toBe(0)
+    expect(tops.get('b')).toBe(108) // a.bottom (100) + gap (8)
+  })
+
+  it('preserves order by desiredTop even when input is unsorted', () => {
+    const specs: CardSpec[] = [
+      { id: 'c', desiredTop: 200, height: 50 },
+      { id: 'a', desiredTop: 0, height: 50 },
+      { id: 'b', desiredTop: 100, height: 50 },
+    ]
+    const tops = solveCardLayout(specs)
+    expect(tops.get('a')).toBe(0)
+    expect(tops.get('b')).toBe(100)
+    expect(tops.get('c')).toBe(200)
+  })
+
+  it('handles a single card', () => {
+    const tops = solveCardLayout([{ id: 'a', desiredTop: 75, height: 100 }])
+    expect(tops.get('a')).toBe(75)
+  })
+
+  it('handles empty input', () => {
+    const tops = solveCardLayout([])
+    expect(tops.size).toBe(0)
+  })
+
+  it('cascades multiple stacked cards through a tight cluster', () => {
+    const specs: CardSpec[] = [
+      { id: 'a', desiredTop: 0, height: 100 },
+      { id: 'b', desiredTop: 10, height: 50 },
+      { id: 'c', desiredTop: 20, height: 50 },
+    ]
+    const tops = solveCardLayout(specs, 4)
+    expect(tops.get('a')).toBe(0)
+    expect(tops.get('b')).toBe(104) // a.bottom + 4
+    expect(tops.get('c')).toBe(158) // b.bottom + 4
+  })
+})

--- a/__tests__/lib/highlights/highlightsRepo.test.ts
+++ b/__tests__/lib/highlights/highlightsRepo.test.ts
@@ -1,0 +1,270 @@
+/**
+ * @jest-environment node
+ */
+
+import { promises as fs } from 'fs'
+import os from 'os'
+import path from 'path'
+
+import {
+  GitHubHighlightsRepo,
+  LocalFsHighlightsRepo,
+  OctokitLike,
+  clearHighlightsCache,
+} from '@/lib/highlights/highlightsRepo'
+import { PostHighlights, emptyPostHighlights } from '@/lib/highlights/schema'
+
+function makePostHighlights(postId: string): PostHighlights {
+  return {
+    postId,
+    schemaVersion: 1,
+    highlights: [
+      {
+        id: 'hl_1',
+        anchor: {
+          startOffset: 0,
+          endOffset: 5,
+          exact: 'Hello',
+          prefix: '',
+          suffix: ' world',
+        },
+        thread: [
+          {
+            id: 'cm_1',
+            parentId: null,
+            body: 'great point',
+            authorName: null,
+            fingerprint: 'fp_abc',
+            country: 'NL',
+            platform: 'web',
+            reactions: {},
+            resolved: false,
+            createdAt: new Date('2026-05-28T10:00:00Z').toISOString(),
+            hidden: false,
+          },
+        ],
+        resolved: false,
+        createdAt: new Date('2026-05-28T10:00:00Z').toISOString(),
+      },
+    ],
+  }
+}
+
+describe('LocalFsHighlightsRepo', () => {
+  let tmpDir: string
+  let repo: LocalFsHighlightsRepo
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'highlights-test-'))
+    repo = new LocalFsHighlightsRepo(tmpDir)
+  })
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it('returns empty PostHighlights when the file does not exist', async () => {
+    const result = await repo.load('post-a')
+    expect(result.data).toEqual(emptyPostHighlights('post-a'))
+    expect(result.sha).toBeNull()
+  })
+
+  it('roundtrips a save → load', async () => {
+    const data = makePostHighlights('post-a')
+    await repo.save('post-a', data, null, 'add highlight')
+
+    const result = await repo.load('post-a')
+    expect(result.data).toEqual(data)
+    expect(result.sha).toBeNull()
+
+    const filePath = path.join(tmpDir, 'data', 'highlights', 'post-a.json')
+    expect((await fs.stat(filePath)).isFile()).toBe(true)
+  })
+
+  it('rejects unsafe postIds (path traversal)', async () => {
+    await expect(repo.load('../etc/passwd')).rejects.toThrow(/Invalid postId/)
+    await expect(
+      repo.save('../etc/passwd', makePostHighlights('a'), null, 'msg'),
+    ).rejects.toThrow(/Invalid postId/)
+  })
+
+  it('rejects malformed PostHighlights on save', async () => {
+    const bad = { postId: 'post-a', schemaVersion: 1, highlights: 'not an array' }
+    await expect(
+      repo.save('post-a', bad as unknown as PostHighlights, null, 'msg'),
+    ).rejects.toThrow()
+  })
+
+  it('rejects malformed JSON on load', async () => {
+    const filePath = path.join(tmpDir, 'data', 'highlights', 'post-a.json')
+    await fs.mkdir(path.dirname(filePath), { recursive: true })
+    await fs.writeFile(filePath, 'not json', 'utf-8')
+
+    await expect(repo.load('post-a')).rejects.toThrow()
+  })
+})
+
+describe('GitHubHighlightsRepo', () => {
+  let octokit: jest.Mocked<OctokitLike['repos']> & { repos: jest.Mocked<OctokitLike['repos']> }
+  let mockRepos: jest.Mocked<OctokitLike['repos']>
+  let repo: GitHubHighlightsRepo
+
+  beforeEach(() => {
+    clearHighlightsCache()
+    mockRepos = {
+      getContent: jest.fn(),
+      createOrUpdateFileContents: jest.fn(),
+    } as unknown as jest.Mocked<OctokitLike['repos']>
+    repo = new GitHubHighlightsRepo({ repos: mockRepos } as OctokitLike, 'test-owner')
+  })
+
+  function fileResponse(content: string, sha: string) {
+    return {
+      data: {
+        type: 'file',
+        encoding: 'base64',
+        content: Buffer.from(content, 'utf-8').toString('base64'),
+        sha,
+      },
+    }
+  }
+
+  function notFoundError(): Error {
+    const err = new Error('Not Found') as Error & { status: number }
+    err.status = 404
+    return err
+  }
+
+  function conflictError(): Error {
+    const err = new Error('Conflict') as Error & { status: number }
+    err.status = 409
+    return err
+  }
+
+  describe('load', () => {
+    it('returns empty PostHighlights on 404', async () => {
+      mockRepos.getContent.mockRejectedValueOnce(notFoundError())
+
+      const result = await repo.load('post-a')
+
+      expect(result.data).toEqual(emptyPostHighlights('post-a'))
+      expect(result.sha).toBeNull()
+      expect(mockRepos.getContent).toHaveBeenCalledTimes(1)
+    })
+
+    it('parses and returns existing file with SHA', async () => {
+      const data = makePostHighlights('post-a')
+      mockRepos.getContent.mockResolvedValueOnce(fileResponse(JSON.stringify(data), 'sha-123'))
+
+      const result = await repo.load('post-a')
+
+      expect(result.data).toEqual(data)
+      expect(result.sha).toBe('sha-123')
+    })
+
+    it('caches the load result for 30s (subsequent loads do not call octokit)', async () => {
+      const data = makePostHighlights('post-a')
+      mockRepos.getContent.mockResolvedValueOnce(fileResponse(JSON.stringify(data), 'sha-1'))
+
+      await repo.load('post-a')
+      await repo.load('post-a')
+
+      expect(mockRepos.getContent).toHaveBeenCalledTimes(1)
+    })
+
+    it('rejects malformed JSON', async () => {
+      mockRepos.getContent.mockResolvedValueOnce(fileResponse('not json', 'sha-x'))
+      await expect(repo.load('post-a')).rejects.toThrow()
+    })
+
+    it('rejects on path-like postId', async () => {
+      await expect(repo.load('../secrets')).rejects.toThrow(/Invalid postId/)
+    })
+  })
+
+  describe('save', () => {
+    it('creates a new file when expectedSha is null (no sha param sent)', async () => {
+      mockRepos.createOrUpdateFileContents.mockResolvedValueOnce({
+        data: { content: { sha: 'new-sha-1' } },
+      })
+
+      const data = makePostHighlights('post-a')
+      const result = await repo.save('post-a', data, null, 'first highlight')
+
+      expect(result.sha).toBe('new-sha-1')
+      const callArgs = mockRepos.createOrUpdateFileContents.mock.calls[0][0]
+      expect(callArgs).toMatchObject({
+        owner: 'test-owner',
+        repo: 'Cofe',
+        path: 'data/highlights/post-a.json',
+        message: 'first highlight',
+      })
+      expect(callArgs.sha).toBeUndefined()
+    })
+
+    it('updates an existing file with the provided sha', async () => {
+      mockRepos.createOrUpdateFileContents.mockResolvedValueOnce({
+        data: { content: { sha: 'sha-2' } },
+      })
+
+      const data = makePostHighlights('post-a')
+      await repo.save('post-a', data, 'sha-1', 'add reply')
+
+      expect(mockRepos.createOrUpdateFileContents.mock.calls[0][0]).toMatchObject({ sha: 'sha-1' })
+    })
+
+    it('retries with fresh SHA on 409 then succeeds', async () => {
+      mockRepos.createOrUpdateFileContents
+        .mockRejectedValueOnce(conflictError())
+        .mockResolvedValueOnce({ data: { content: { sha: 'sha-final' } } })
+      const data = makePostHighlights('post-a')
+      mockRepos.getContent.mockResolvedValueOnce(
+        fileResponse(JSON.stringify(data), 'sha-fresh'),
+      )
+
+      const result = await repo.save('post-a', data, 'sha-stale', 'commit')
+
+      expect(result.sha).toBe('sha-final')
+      expect(mockRepos.createOrUpdateFileContents).toHaveBeenCalledTimes(2)
+      // Second call must use the freshly read SHA, not the stale one
+      expect(mockRepos.createOrUpdateFileContents.mock.calls[1][0]).toMatchObject({ sha: 'sha-fresh' })
+    })
+
+    it('throws after 3 retries of persistent 409', async () => {
+      mockRepos.createOrUpdateFileContents.mockRejectedValue(conflictError())
+      mockRepos.getContent.mockResolvedValue(
+        fileResponse(JSON.stringify(makePostHighlights('post-a')), 'sha-x'),
+      )
+
+      const data = makePostHighlights('post-a')
+      await expect(repo.save('post-a', data, 'sha-y', 'commit')).rejects.toThrow(
+        /retries due to write contention/,
+      )
+      expect(mockRepos.createOrUpdateFileContents).toHaveBeenCalledTimes(3)
+    })
+
+    it('invalidates cache on successful save (next load re-fetches)', async () => {
+      const data = makePostHighlights('post-a')
+      // First load → populates cache
+      mockRepos.getContent.mockResolvedValueOnce(fileResponse(JSON.stringify(data), 'sha-1'))
+      await repo.load('post-a')
+      // Save → invalidates / overwrites cache with new sha
+      mockRepos.createOrUpdateFileContents.mockResolvedValueOnce({
+        data: { content: { sha: 'sha-2' } },
+      })
+      await repo.save('post-a', data, 'sha-1', 'msg')
+      // Subsequent load uses cache (sha-2), no octokit fetch
+      const result = await repo.load('post-a')
+      expect(result.sha).toBe('sha-2')
+      expect(mockRepos.getContent).toHaveBeenCalledTimes(1) // only the first load
+    })
+
+    it('rejects malformed PostHighlights without calling octokit', async () => {
+      const bad = { postId: 'post-a', schemaVersion: 1, highlights: 'nope' }
+      await expect(
+        repo.save('post-a', bad as unknown as PostHighlights, null, 'msg'),
+      ).rejects.toThrow()
+      expect(mockRepos.createOrUpdateFileContents).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/__tests__/lib/highlights/highlightsRepo.test.ts
+++ b/__tests__/lib/highlights/highlightsRepo.test.ts
@@ -88,6 +88,32 @@ describe('LocalFsHighlightsRepo', () => {
     ).rejects.toThrow(/Invalid postId/)
   })
 
+  it('rejects postIds containing slashes, null bytes, or leading dots', async () => {
+    await expect(repo.load('foo/bar')).rejects.toThrow(/Invalid postId/)
+    await expect(repo.load('foo\\bar')).rejects.toThrow(/Invalid postId/)
+    await expect(repo.load('foo\x00bar')).rejects.toThrow(/Invalid postId/)
+    await expect(repo.load('foo..bar')).rejects.toThrow(/Invalid postId/)
+    await expect(repo.load('.hidden')).rejects.toThrow(/Invalid postId/)
+    await expect(repo.load('')).rejects.toThrow(/Invalid postId/)
+  })
+
+  it('accepts CJK / full-width punctuation in postIds', async () => {
+    // Real post IDs from blog.minghe.me's data/blog/ folder
+    const okIds = [
+      '我做了一款旅行记录应用：mile', // Chinese + full-width colon
+      '四月的尾巴逛德国-柏林',
+      '华为鸿蒙-harmaryos-next-线下活动小记',
+      '逛逛济州岛',
+      '2017-summary',
+    ]
+    for (const id of okIds) {
+      // Should not throw — the file just doesn't exist yet
+      const result = await repo.load(id)
+      expect(result.data.postId).toBe(id)
+      expect(result.sha).toBeNull()
+    }
+  })
+
   it('rejects malformed PostHighlights on save', async () => {
     const bad = { postId: 'post-a', schemaVersion: 1, highlights: 'not an array' }
     await expect(

--- a/__tests__/lib/highlights/rateLimit.test.ts
+++ b/__tests__/lib/highlights/rateLimit.test.ts
@@ -1,0 +1,62 @@
+/**
+ * @jest-environment node
+ */
+
+import {
+  checkCommentRateLimit,
+  checkReactionRateLimit,
+  clearAllRateLimits,
+} from '@/lib/highlights/rateLimit'
+
+describe('rateLimit', () => {
+  beforeEach(() => clearAllRateLimits())
+
+  it('allows up to max requests within the window', () => {
+    const config = { max: 3, windowMs: 60_000 }
+    const r1 = checkCommentRateLimit('fp1', config, 1000)
+    const r2 = checkCommentRateLimit('fp1', config, 2000)
+    const r3 = checkCommentRateLimit('fp1', config, 3000)
+    expect([r1.allowed, r2.allowed, r3.allowed]).toEqual([true, true, true])
+    expect(r3.remaining).toBe(0)
+  })
+
+  it('rejects beyond max within the window', () => {
+    const config = { max: 2, windowMs: 60_000 }
+    checkCommentRateLimit('fp1', config, 1000)
+    checkCommentRateLimit('fp1', config, 2000)
+    const r3 = checkCommentRateLimit('fp1', config, 3000)
+    expect(r3.allowed).toBe(false)
+    expect(r3.retryAfterMs).toBeGreaterThan(0)
+  })
+
+  it('decays older stamps outside the window', () => {
+    const config = { max: 2, windowMs: 60_000 }
+    checkCommentRateLimit('fp1', config, 1000)
+    checkCommentRateLimit('fp1', config, 2000)
+    // Now 70s later — old stamps are outside the window
+    const r3 = checkCommentRateLimit('fp1', config, 71_000)
+    expect(r3.allowed).toBe(true)
+  })
+
+  it('isolates fingerprints from each other', () => {
+    const config = { max: 1, windowMs: 60_000 }
+    expect(checkCommentRateLimit('fp1', config, 1000).allowed).toBe(true)
+    expect(checkCommentRateLimit('fp2', config, 1000).allowed).toBe(true)
+    expect(checkCommentRateLimit('fp1', config, 2000).allowed).toBe(false)
+  })
+
+  it('uses separate buckets for comment vs reaction limits', () => {
+    const config = { max: 1, windowMs: 60_000 }
+    expect(checkCommentRateLimit('fp1', config, 1000).allowed).toBe(true)
+    // Reaction bucket is independent — fp1 hasn't hit reaction limit yet
+    expect(checkReactionRateLimit('fp1', config, 1000).allowed).toBe(true)
+  })
+
+  it('returns retryAfterMs that reflects time until oldest stamp ages out', () => {
+    const config = { max: 1, windowMs: 60_000 }
+    checkCommentRateLimit('fp1', config, 0)
+    const r = checkCommentRateLimit('fp1', config, 10_000)
+    // Oldest stamp at t=0, window ends at t=60_000, current at t=10_000 → 50_000ms remaining
+    expect(r.retryAfterMs).toBe(50_000)
+  })
+})

--- a/app/api/blog/[id]/highlights/[hid]/comments/[cid]/reactions/route.ts
+++ b/app/api/blog/[id]/highlights/[hid]/comments/[cid]/reactions/route.ts
@@ -1,0 +1,81 @@
+import { NextRequest } from 'next/server'
+import { z } from 'zod'
+
+import { getHighlightsRepo } from '@/lib/highlights/highlightsRepo'
+import { checkReactionRateLimit } from '@/lib/highlights/rateLimit'
+import {
+  ApiBodyError,
+  apiError,
+  apiOk,
+  extractIdentity,
+  parseBody,
+} from '@/lib/highlights/server'
+import { Reactions } from '@/lib/highlights/schema'
+
+const ReactionBody = z.object({
+  emoji: z.string().min(1).max(8),
+})
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { id: string; hid: string; cid: string } },
+) {
+  try {
+    const body = await parseBody(req, ReactionBody)
+    const identity = extractIdentity(req)
+
+    const rl = checkReactionRateLimit(identity.fingerprint)
+    if (!rl.allowed) {
+      return apiError(
+        `Too many reactions. Retry after ${Math.ceil(rl.retryAfterMs / 1000)}s`,
+        429,
+      )
+    }
+
+    const repo = getHighlightsRepo()
+    const { data, sha } = await repo.load(params.id)
+
+    const highlight = data.highlights.find((h) => h.id === params.hid)
+    if (!highlight) return apiError('Highlight not found', 404)
+    const comment = highlight.thread.find((c) => c.id === params.cid)
+    if (!comment) return apiError('Comment not found', 404)
+
+    const reactions: Reactions = { ...comment.reactions }
+    const current = reactions[body.emoji] ?? []
+    const idx = current.indexOf(identity.fingerprint)
+    const next = idx === -1 ? [...current, identity.fingerprint] : current.filter((_, i) => i !== idx)
+
+    if (next.length === 0) {
+      delete reactions[body.emoji]
+    } else {
+      reactions[body.emoji] = next
+    }
+
+    const updated = {
+      ...data,
+      highlights: data.highlights.map((h) =>
+        h.id === params.hid
+          ? {
+              ...h,
+              thread: h.thread.map((c) =>
+                c.id === params.cid ? { ...c, reactions } : c,
+              ),
+            }
+          : h,
+      ),
+    }
+
+    await repo.save(
+      params.id,
+      updated,
+      sha,
+      `Toggle reaction ${body.emoji} on ${params.cid}`,
+    )
+
+    return apiOk({ reactions })
+  } catch (err) {
+    if (err instanceof ApiBodyError) return apiError(err.message, 400)
+    console.error('POST /reactions failed', err)
+    return apiError('Failed to toggle reaction', 500)
+  }
+}

--- a/app/api/blog/[id]/highlights/[hid]/comments/[cid]/route.ts
+++ b/app/api/blog/[id]/highlights/[hid]/comments/[cid]/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest } from 'next/server'
+
+import { getHighlightsRepo } from '@/lib/highlights/highlightsRepo'
+import { apiError, apiOk, getOwnerToken, isOwner } from '@/lib/highlights/server'
+
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: { id: string; hid: string; cid: string } },
+) {
+  try {
+    if (!(await isOwner())) return apiError('Owner authentication required', 403)
+
+    const ownerToken = await getOwnerToken()
+    const repo = getHighlightsRepo({ ownerToken })
+    const { data, sha } = await repo.load(params.id)
+
+    const highlight = data.highlights.find((h) => h.id === params.hid)
+    if (!highlight) return apiError('Highlight not found', 404)
+    if (!highlight.thread.some((c) => c.id === params.cid)) {
+      return apiError('Comment not found', 404)
+    }
+
+    // Deleting the root comment removes the entire highlight.
+    const isRoot = highlight.thread[0]?.id === params.cid
+    let updated
+    if (isRoot) {
+      updated = {
+        ...data,
+        highlights: data.highlights.filter((h) => h.id !== params.hid),
+      }
+    } else {
+      updated = {
+        ...data,
+        highlights: data.highlights.map((h) =>
+          h.id === params.hid
+            ? { ...h, thread: h.thread.filter((c) => c.id !== params.cid) }
+            : h,
+        ),
+      }
+    }
+
+    await repo.save(
+      params.id,
+      updated,
+      sha,
+      `Delete comment ${params.cid}${isRoot ? ' (and parent highlight)' : ''}`,
+    )
+    return apiOk({ ok: true, removedHighlight: isRoot })
+  } catch (err) {
+    console.error('DELETE /comments/[cid] failed', err)
+    return apiError('Failed to delete comment', 500)
+  }
+}

--- a/app/api/blog/[id]/highlights/[hid]/replies/route.ts
+++ b/app/api/blog/[id]/highlights/[hid]/replies/route.ts
@@ -1,0 +1,81 @@
+import { randomUUID } from 'crypto'
+import { NextRequest } from 'next/server'
+import { z } from 'zod'
+
+import { getHighlightsRepo } from '@/lib/highlights/highlightsRepo'
+import { checkCommentRateLimit } from '@/lib/highlights/rateLimit'
+import {
+  ApiBodyError,
+  apiError,
+  apiOk,
+  extractIdentity,
+  parseBody,
+} from '@/lib/highlights/server'
+import { InlineComment } from '@/lib/highlights/schema'
+
+const ReplyBody = z.object({
+  parentId: z.string().min(1).max(64).nullable().optional(),
+  body: z.string().min(1).max(2000),
+  authorName: z.string().max(40).nullable().optional(),
+  website: z.string().max(0).optional(),
+})
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { id: string; hid: string } },
+) {
+  try {
+    const body = await parseBody(req, ReplyBody)
+    if (body.website && body.website.length > 0) {
+      return apiError('Rejected', 400)
+    }
+
+    const identity = extractIdentity(req)
+    const rl = checkCommentRateLimit(identity.fingerprint)
+    if (!rl.allowed) {
+      return apiError(
+        `Too many comments. Retry after ${Math.ceil(rl.retryAfterMs / 1000)}s`,
+        429,
+      )
+    }
+
+    const repo = getHighlightsRepo()
+    const { data, sha } = await repo.load(params.id)
+
+    const target = data.highlights.find((h) => h.id === params.hid)
+    if (!target) return apiError('Highlight not found', 404)
+
+    if (body.parentId && !target.thread.some((c) => c.id === body.parentId)) {
+      return apiError('Parent comment not found in this thread', 400)
+    }
+
+    const now = new Date().toISOString()
+    const reply: InlineComment = {
+      id: `cm_${randomUUID()}`,
+      parentId: body.parentId ?? null,
+      body: body.body.trim(),
+      authorName: body.authorName ?? null,
+      fingerprint: identity.fingerprint,
+      country: identity.country,
+      platform: identity.platform,
+      reactions: {},
+      resolved: false,
+      createdAt: now,
+      hidden: false,
+    }
+
+    const updated = {
+      ...data,
+      highlights: data.highlights.map((h) =>
+        h.id === params.hid ? { ...h, thread: [...h.thread, reply] } : h,
+      ),
+    }
+
+    await repo.save(params.id, updated, sha, `Reply on ${params.hid}`)
+    return apiOk({ comment: reply })
+  } catch (err) {
+    if (err instanceof ApiBodyError) return apiError(err.message, 400)
+    console.error('POST /highlights/[hid]/replies failed', err)
+    return apiError('Failed to add reply', 500)
+  }
+}

--- a/app/api/blog/[id]/highlights/[hid]/resolve/route.ts
+++ b/app/api/blog/[id]/highlights/[hid]/resolve/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest } from 'next/server'
+import { z } from 'zod'
+
+import { getHighlightsRepo } from '@/lib/highlights/highlightsRepo'
+import {
+  ApiBodyError,
+  apiError,
+  apiOk,
+  getOwnerToken,
+  isOwner,
+  parseBody,
+} from '@/lib/highlights/server'
+
+const ResolveBody = z.object({
+  resolved: z.boolean(),
+})
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { id: string; hid: string } },
+) {
+  try {
+    if (!(await isOwner())) return apiError('Owner authentication required', 403)
+    const body = await parseBody(req, ResolveBody)
+
+    const ownerToken = await getOwnerToken()
+    const repo = getHighlightsRepo({ ownerToken })
+    const { data, sha } = await repo.load(params.id)
+
+    const target = data.highlights.find((h) => h.id === params.hid)
+    if (!target) return apiError('Highlight not found', 404)
+    if (target.resolved === body.resolved) {
+      return apiOk({ highlight: target })
+    }
+
+    const updated = {
+      ...data,
+      highlights: data.highlights.map((h) =>
+        h.id === params.hid ? { ...h, resolved: body.resolved } : h,
+      ),
+    }
+
+    await repo.save(
+      params.id,
+      updated,
+      sha,
+      `${body.resolved ? 'Resolve' : 'Reopen'} highlight ${params.hid}`,
+    )
+
+    const next = updated.highlights.find((h) => h.id === params.hid)!
+    return apiOk({ highlight: next })
+  } catch (err) {
+    if (err instanceof ApiBodyError) return apiError(err.message, 400)
+    console.error('POST /resolve failed', err)
+    return apiError('Failed to update highlight', 500)
+  }
+}

--- a/app/api/blog/[id]/highlights/[hid]/route.ts
+++ b/app/api/blog/[id]/highlights/[hid]/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest } from 'next/server'
+
+import { getHighlightsRepo } from '@/lib/highlights/highlightsRepo'
+import { apiError, apiOk, getOwnerToken, isOwner } from '@/lib/highlights/server'
+
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: { id: string; hid: string } },
+) {
+  try {
+    if (!(await isOwner())) return apiError('Owner authentication required', 403)
+
+    const ownerToken = await getOwnerToken()
+    const repo = getHighlightsRepo({ ownerToken })
+    const { data, sha } = await repo.load(params.id)
+
+    if (!data.highlights.some((h) => h.id === params.hid)) {
+      return apiError('Highlight not found', 404)
+    }
+
+    const updated = {
+      ...data,
+      highlights: data.highlights.filter((h) => h.id !== params.hid),
+    }
+
+    await repo.save(params.id, updated, sha, `Delete highlight ${params.hid}`)
+    return apiOk({ ok: true })
+  } catch (err) {
+    console.error('DELETE /highlights/[hid] failed', err)
+    return apiError('Failed to delete highlight', 500)
+  }
+}

--- a/app/api/blog/[id]/highlights/route.ts
+++ b/app/api/blog/[id]/highlights/route.ts
@@ -1,0 +1,106 @@
+import { randomUUID } from 'crypto'
+import { NextRequest } from 'next/server'
+import { z } from 'zod'
+
+import { getHighlightsRepo } from '@/lib/highlights/highlightsRepo'
+import { checkCommentRateLimit } from '@/lib/highlights/rateLimit'
+import {
+  ApiBodyError,
+  apiError,
+  apiOk,
+  extractIdentity,
+  isOwner,
+  parseBody,
+} from '@/lib/highlights/server'
+import {
+  Highlight,
+  HighlightAnchorSchema,
+  PostHighlights,
+} from '@/lib/highlights/schema'
+
+const CreateHighlightBody = z.object({
+  anchor: HighlightAnchorSchema,
+  body: z.string().min(1).max(2000),
+  authorName: z.string().max(40).nullable().optional(),
+  // Honeypot — bots tend to fill every field; humans never see it.
+  website: z.string().max(0).optional(),
+})
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  try {
+    const repo = getHighlightsRepo()
+    const { data } = await repo.load(params.id)
+    const identity = extractIdentity(request)
+    const owner = await isOwner()
+    return apiOk({
+      ...data,
+      currentFingerprint: identity.fingerprint,
+      isOwner: owner,
+    })
+  } catch (err) {
+    console.error('GET /highlights failed', err)
+    return apiError('Failed to load highlights', 500)
+  }
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  try {
+    const body = await parseBody(req, CreateHighlightBody)
+    if (body.website && body.website.length > 0) {
+      return apiError('Rejected', 400)
+    }
+
+    const identity = extractIdentity(req)
+    const rl = checkCommentRateLimit(identity.fingerprint)
+    if (!rl.allowed) {
+      return apiError(
+        `Too many comments. Retry after ${Math.ceil(rl.retryAfterMs / 1000)}s`,
+        429,
+      )
+    }
+
+    const repo = getHighlightsRepo()
+    const { data, sha } = await repo.load(params.id)
+
+    const now = new Date().toISOString()
+    const newHighlight: Highlight = {
+      id: `hl_${randomUUID()}`,
+      anchor: body.anchor,
+      thread: [
+        {
+          id: `cm_${randomUUID()}`,
+          parentId: null,
+          body: body.body.trim(),
+          authorName: body.authorName ?? null,
+          fingerprint: identity.fingerprint,
+          country: identity.country,
+          platform: identity.platform,
+          reactions: {},
+          resolved: false,
+          createdAt: now,
+          hidden: false,
+        },
+      ],
+      resolved: false,
+      createdAt: now,
+    }
+
+    const updated: PostHighlights = {
+      ...data,
+      highlights: [...data.highlights, newHighlight],
+    }
+
+    await repo.save(params.id, updated, sha, `Add highlight on ${params.id}`)
+    return apiOk({ highlight: newHighlight })
+  } catch (err) {
+    if (err instanceof ApiBodyError) return apiError(err.message, 400)
+    console.error('POST /highlights failed', err)
+    return apiError('Failed to create highlight', 500)
+  }
+}

--- a/app/blog/[id]/component.tsx
+++ b/app/blog/[id]/component.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { BlogPostContent } from '@/components/BlogPostContent'
+import { HighlightLayer } from '@/components/Highlights/HighlightLayer'
 import { useUmamiTracking } from '@/components/Analytics'
 import type { BlogPost } from '@/lib/types'
 import {
@@ -155,14 +156,16 @@ export const PostContainer = ({ post, discussionsComponent }: { post: BlogPost, 
   )
 
   return (
-    <BlogPostContent
-      title={decodedTitle}
-      date={post.date}
-      content={contentWithoutFrontmatter}
-      slug={post.id}
-      headerContent={status === 'authenticated' ? headerContent : null}
-      discussionsComponent={discussionsComponent}
-      location={post.city ? { city: post.city, street: post.street } : undefined}
-    />
+    <HighlightLayer postId={post.id}>
+      <BlogPostContent
+        title={decodedTitle}
+        date={post.date}
+        content={contentWithoutFrontmatter}
+        slug={post.id}
+        headerContent={status === 'authenticated' ? headerContent : null}
+        discussionsComponent={discussionsComponent}
+        location={post.city ? { city: post.city, street: post.street } : undefined}
+      />
+    </HighlightLayer>
   )
 }

--- a/components/Highlights/CommentCard.tsx
+++ b/components/Highlights/CommentCard.tsx
@@ -1,0 +1,177 @@
+'use client'
+
+import { formatDistanceToNow } from 'date-fns'
+import { Trash2, CheckCircle, RotateCcw } from 'lucide-react'
+import { useState } from 'react'
+
+import { Highlight, InlineComment, Reactions as ReactionsT } from '@/lib/highlights/schema'
+import { setFocused, useFocusedHighlight } from '@/lib/highlights/syncFocus'
+
+import { CommentComposer } from './CommentComposer'
+import { Reactions } from './Reactions'
+
+interface CommentCardProps {
+  highlight: Highlight
+  fingerprint: string | null
+  isOwner: boolean
+  onReply: (
+    highlightId: string,
+    parentId: string | null,
+    body: string,
+    authorName: string | null,
+  ) => Promise<void>
+  onReact: (highlightId: string, commentId: string, emoji: string) => Promise<void>
+  onResolve: (highlightId: string, resolved: boolean) => Promise<void>
+  onDelete: (highlightId: string, commentId?: string) => Promise<void>
+}
+
+/**
+ * Renders one highlight's thread as a Google Docs-style card. The thread's
+ * first comment is the root; the rest render indented as replies. A reply
+ * composer lives at the bottom and reveals on click.
+ */
+export function CommentCard(props: CommentCardProps) {
+  const { highlight, fingerprint, isOwner, onReply, onReact, onResolve, onDelete } = props
+  const focused = useFocusedHighlight() === highlight.id
+  const [replyOpen, setReplyOpen] = useState(false)
+
+  const root = highlight.thread[0]
+  const replies = highlight.thread.slice(1)
+
+  return (
+    <div
+      data-card-for={highlight.id}
+      onMouseEnter={() => setFocused(highlight.id)}
+      onMouseLeave={() => setFocused(null)}
+      className={[
+        'rounded-lg border bg-white p-3 shadow-sm transition-all',
+        focused ? 'border-amber-400 shadow-md' : 'border-gray-200',
+        highlight.resolved ? 'opacity-60' : '',
+      ].join(' ')}
+    >
+      <CommentBody comment={root} fingerprint={fingerprint} isOwner={isOwner}
+        onReact={(emoji) => onReact(highlight.id, root.id, emoji)}
+        onDelete={() => onDelete(highlight.id, root.id)}
+      />
+
+      {replies.length > 0 && (
+        <div className='mt-2 space-y-2 border-l-2 border-gray-100 pl-2'>
+          {replies.map((reply) => (
+            <CommentBody
+              key={reply.id}
+              comment={reply}
+              fingerprint={fingerprint}
+              isOwner={isOwner}
+              onReact={(emoji) => onReact(highlight.id, reply.id, emoji)}
+              onDelete={() => onDelete(highlight.id, reply.id)}
+              compact
+            />
+          ))}
+        </div>
+      )}
+
+      <div className='mt-2 flex items-center justify-between gap-2'>
+        {replyOpen ? null : (
+          <button
+            type='button'
+            onClick={() => setReplyOpen(true)}
+            className='text-xs font-medium text-amber-600 hover:text-amber-700'
+          >
+            Reply
+          </button>
+        )}
+        {isOwner && (
+          <div className='ml-auto flex items-center gap-1'>
+            <button
+              type='button'
+              onClick={() => onResolve(highlight.id, !highlight.resolved)}
+              className='inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs text-gray-500 hover:bg-gray-100'
+              aria-label={highlight.resolved ? 'Reopen' : 'Resolve'}
+            >
+              {highlight.resolved ? <RotateCcw className='h-3 w-3' /> : <CheckCircle className='h-3 w-3' />}
+              {highlight.resolved ? 'Reopen' : 'Resolve'}
+            </button>
+            <button
+              type='button'
+              onClick={() => onDelete(highlight.id)}
+              className='inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs text-red-500 hover:bg-red-50'
+              aria-label='Delete highlight'
+            >
+              <Trash2 className='h-3 w-3' />
+            </button>
+          </div>
+        )}
+      </div>
+
+      {replyOpen && (
+        <div className='mt-2'>
+          <CommentComposer
+            placeholder='Reply…'
+            submitLabel='Reply'
+            onSubmit={async (body, name) => {
+              await onReply(highlight.id, root.id, body, name)
+              setReplyOpen(false)
+            }}
+            onCancel={() => setReplyOpen(false)}
+          />
+        </div>
+      )}
+    </div>
+  )
+}
+
+function CommentBody({
+  comment,
+  fingerprint,
+  isOwner,
+  onReact,
+  onDelete,
+  compact,
+}: {
+  comment: InlineComment
+  fingerprint: string | null
+  isOwner: boolean
+  onReact: (emoji: string) => Promise<void>
+  onDelete: () => Promise<void>
+  compact?: boolean
+}) {
+  if (comment.hidden) {
+    return <div className='text-xs italic text-gray-400'>(removed)</div>
+  }
+
+  const displayName = comment.authorName?.trim() || `Anonymous ${comment.fingerprint.slice(0, 4)}`
+  const time = formatDistanceToNow(new Date(comment.createdAt), { addSuffix: true })
+
+  return (
+    <div className={compact ? 'text-xs' : 'text-sm'}>
+      <div className='flex items-center justify-between gap-2'>
+        <div className='flex items-center gap-1.5'>
+          <span className='font-medium text-gray-900'>{displayName}</span>
+          <span className='text-[11px] text-gray-400'>· {time}</span>
+        </div>
+        {isOwner && compact && (
+          <button
+            type='button'
+            onClick={onDelete}
+            className='text-[11px] text-red-500 hover:underline'
+            aria-label='Delete reply'
+          >
+            <Trash2 className='h-3 w-3' />
+          </button>
+        )}
+      </div>
+      <div className={['mt-1 whitespace-pre-wrap text-gray-700', compact ? '' : ''].join(' ')}>
+        {comment.body}
+      </div>
+      <div className='mt-1.5'>
+        <Reactions
+          reactions={comment.reactions as ReactionsT}
+          fingerprint={fingerprint}
+          onToggle={(emoji) => {
+            void onReact(emoji)
+          }}
+        />
+      </div>
+    </div>
+  )
+}

--- a/components/Highlights/CommentComposer.tsx
+++ b/components/Highlights/CommentComposer.tsx
@@ -1,0 +1,117 @@
+'use client'
+
+import { useState } from 'react'
+import { Send, X } from 'lucide-react'
+
+interface CommentComposerProps {
+  /** Optional initial body (e.g. user has been re-prompted to retry). */
+  initialBody?: string
+  initialName?: string
+  placeholder?: string
+  submitLabel?: string
+  onSubmit: (body: string, authorName: string | null) => Promise<void>
+  onCancel?: () => void
+  disabled?: boolean
+}
+
+/**
+ * Reusable composer for both new highlights and replies. Body + optional
+ * display name. Honeypot field is rendered but visually hidden — bots
+ * tend to fill every form field, humans don't see it.
+ */
+export function CommentComposer({
+  initialBody = '',
+  initialName = '',
+  placeholder = 'Add a comment…',
+  submitLabel = 'Comment',
+  onSubmit,
+  onCancel,
+  disabled,
+}: CommentComposerProps) {
+  const [body, setBody] = useState(initialBody)
+  const [name, setName] = useState(initialName)
+  const [website, setWebsite] = useState('') // honeypot
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleSubmit() {
+    if (!body.trim() || submitting || disabled) return
+    setSubmitting(true)
+    setError(null)
+    try {
+      // Honeypot: server already rejects, but skip the call client-side.
+      if (website.length > 0) {
+        setError('Submission blocked')
+        return
+      }
+      await onSubmit(body.trim(), name.trim() ? name.trim() : null)
+      setBody('')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to submit')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className='flex flex-col gap-2 rounded-lg border border-gray-200 bg-white p-3'>
+      <textarea
+        value={body}
+        onChange={(e) => setBody(e.target.value)}
+        placeholder={placeholder}
+        rows={3}
+        maxLength={2000}
+        disabled={submitting || disabled}
+        className='w-full resize-none rounded border border-gray-200 bg-white px-2 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:border-amber-400 focus:outline-none'
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+            e.preventDefault()
+            handleSubmit()
+          }
+        }}
+      />
+      <input
+        type='text'
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        placeholder='Your name (optional)'
+        maxLength={40}
+        disabled={submitting || disabled}
+        className='w-full rounded border border-gray-200 bg-white px-2 py-1 text-xs text-gray-700 placeholder-gray-400 focus:border-amber-400 focus:outline-none'
+      />
+      {/* Honeypot — visually hidden, never tabbable. */}
+      <input
+        type='text'
+        value={website}
+        onChange={(e) => setWebsite(e.target.value)}
+        tabIndex={-1}
+        autoComplete='off'
+        aria-hidden='true'
+        className='absolute -left-[9999px] -top-[9999px] h-0 w-0 opacity-0'
+      />
+      {error && <div className='text-xs text-red-600'>{error}</div>}
+      <div className='flex items-center justify-end gap-2'>
+        {onCancel && (
+          <button
+            type='button'
+            onClick={onCancel}
+            disabled={submitting}
+            className='inline-flex h-7 items-center gap-1 rounded px-2 text-xs text-gray-600 hover:bg-gray-100'
+          >
+            <X className='h-3 w-3' />
+            Cancel
+          </button>
+        )}
+        <button
+          type='button'
+          onClick={handleSubmit}
+          disabled={submitting || disabled || !body.trim()}
+          className='inline-flex h-7 items-center gap-1 rounded bg-amber-400 px-3 text-xs font-medium text-white shadow-sm hover:bg-amber-500 disabled:cursor-not-allowed disabled:opacity-50'
+        >
+          <Send className='h-3 w-3' />
+          {submitting ? 'Sending…' : submitLabel}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/components/Highlights/CommentRail.tsx
+++ b/components/Highlights/CommentRail.tsx
@@ -1,0 +1,137 @@
+'use client'
+
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+
+import { anchorToRange } from '@/lib/highlights/anchoring'
+import { CardSpec, solveCardLayout } from '@/lib/highlights/cardLayout'
+import { Highlight } from '@/lib/highlights/schema'
+
+import { CommentCard } from './CommentCard'
+
+interface CommentRailProps {
+  highlights: Highlight[]
+  articleEl: HTMLElement | null
+  recomputeKey: number
+  fingerprint: string | null
+  isOwner: boolean
+  onReply: (
+    highlightId: string,
+    parentId: string | null,
+    body: string,
+    authorName: string | null,
+  ) => Promise<void>
+  onReact: (highlightId: string, commentId: string, emoji: string) => Promise<void>
+  onResolve: (highlightId: string, resolved: boolean) => Promise<void>
+  onDelete: (highlightId: string, commentId?: string) => Promise<void>
+}
+
+const DEFAULT_HEIGHT = 100
+
+/**
+ * Right-rail container for comment cards, Google Docs-style.
+ *
+ * Each card is positioned absolutely at a constraint-solved top so cards
+ * never overlap. Heights are measured live via ResizeObserver; positions
+ * recompute on heights change, on `recomputeKey` (article resize / font
+ * load), and on the highlights list itself.
+ */
+export function CommentRail(props: CommentRailProps) {
+  const { highlights, articleEl, recomputeKey } = props
+  const [heights, setHeights] = useState<Record<string, number>>({})
+  const [desiredTops, setDesiredTops] = useState<Record<string, number>>({})
+  const observersRef = useRef(new Map<string, ResizeObserver>())
+
+  // Compute desired tops from anchors
+  useLayoutEffect(() => {
+    if (!articleEl) return
+    const articleRect = articleEl.getBoundingClientRect()
+    const next: Record<string, number> = {}
+    for (const h of highlights) {
+      const range = anchorToRange(h.anchor, articleEl)
+      if (!range) continue
+      const r = range.getBoundingClientRect()
+      next[h.id] = r.top - articleRect.top
+    }
+    setDesiredTops(next)
+  }, [highlights, articleEl, recomputeKey])
+
+  // Solve layout
+  const visible = highlights.filter((h) => desiredTops[h.id] !== undefined)
+  const specs: CardSpec[] = visible.map((h) => ({
+    id: h.id,
+    desiredTop: desiredTops[h.id]!,
+    height: heights[h.id] ?? DEFAULT_HEIGHT,
+  }))
+  const tops = solveCardLayout(specs)
+
+  // Tear down observers on unmount
+  useEffect(() => {
+    const observers = observersRef.current
+    return () => {
+      observers.forEach((ro) => ro.disconnect())
+      observers.clear()
+    }
+  }, [])
+
+  // Tear down observers for removed highlights
+  useEffect(() => {
+    const known = new Set(highlights.map((h) => h.id))
+    observersRef.current.forEach((ro, id) => {
+      if (!known.has(id)) {
+        ro.disconnect()
+        observersRef.current.delete(id)
+      }
+    })
+  }, [highlights])
+
+  function attachCardRef(id: string) {
+    return (el: HTMLDivElement | null) => {
+      const existing = observersRef.current.get(id)
+      if (existing) {
+        existing.disconnect()
+        observersRef.current.delete(id)
+      }
+      if (!el) return
+      const ro = new ResizeObserver((entries) => {
+        const entry = entries[0]
+        if (!entry) return
+        const next = entry.contentRect.height
+        setHeights((prev) => (prev[id] === next ? prev : { ...prev, [id]: next }))
+      })
+      ro.observe(el)
+      observersRef.current.set(id, ro)
+    }
+  }
+
+  if (visible.length === 0) return null
+
+  // Total rail height: bottom of the lowest card
+  const railHeight =
+    Math.max(
+      ...specs.map((s) => (tops.get(s.id) ?? 0) + (heights[s.id] ?? DEFAULT_HEIGHT)),
+      0,
+    )
+
+  return (
+    <div className='relative w-full' style={{ minHeight: railHeight }}>
+      {visible.map((h) => (
+        <div
+          key={h.id}
+          ref={attachCardRef(h.id)}
+          className='absolute left-0 w-full'
+          style={{ top: tops.get(h.id) ?? 0 }}
+        >
+          <CommentCard
+            highlight={h}
+            fingerprint={props.fingerprint}
+            isOwner={props.isOwner}
+            onReply={props.onReply}
+            onReact={props.onReact}
+            onResolve={props.onResolve}
+            onDelete={props.onDelete}
+          />
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/components/Highlights/HighlightLayer.tsx
+++ b/components/Highlights/HighlightLayer.tsx
@@ -1,0 +1,267 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import { rangeToAnchor } from '@/lib/highlights/anchoring'
+import {
+  createHighlight,
+  createReply,
+  deleteComment,
+  deleteHighlight,
+  fetchHighlights,
+  setHighlightResolved,
+  toggleReaction,
+} from '@/lib/highlights/clientApi'
+import { Highlight, HighlightAnchor } from '@/lib/highlights/schema'
+
+import { CommentCard } from './CommentCard'
+import { CommentComposer } from './CommentComposer'
+import { CommentRail } from './CommentRail'
+import { HighlightMark } from './HighlightMark'
+import { SelectionToolbar } from './SelectionToolbar'
+
+interface HighlightLayerProps {
+  postId: string
+  children: React.ReactNode
+}
+
+/**
+ * Top-level orchestrator for the inline-comments feature on a blog post.
+ *
+ * Wraps the post's article content with:
+ *   - selection capture + floating "+" toolbar
+ *   - overlay highlight marks
+ *   - right-rail of Google Docs-style comment cards
+ *   - composer for new highlights and replies
+ *
+ * Does not modify `BlogPostContent` — the article DOM stays untouched and
+ * we render anchored marks/cards on top.
+ */
+export function HighlightLayer({ postId, children }: HighlightLayerProps) {
+  const articleRef = useRef<HTMLDivElement>(null)
+  const [highlights, setHighlights] = useState<Highlight[]>([])
+  const [fingerprint, setFingerprint] = useState<string | null>(null)
+  const [isOwner, setIsOwner] = useState(false)
+  const [pending, setPending] = useState<HighlightAnchor | null>(null)
+  const [recomputeKey, setRecomputeKey] = useState(0)
+  const [error, setError] = useState<string | null>(null)
+
+  // Fetch highlights on mount
+  useEffect(() => {
+    let cancelled = false
+    fetchHighlights(postId)
+      .then((data) => {
+        if (cancelled) return
+        setHighlights(data.highlights)
+        setFingerprint(data.currentFingerprint)
+        setIsOwner(data.isOwner)
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          console.error('Failed to load highlights', err)
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [postId])
+
+  // Recompute marks/cards on article resize, font load, scroll-zoom
+  useEffect(() => {
+    const article = articleRef.current
+    if (!article) return
+    const ro = new ResizeObserver(() => setRecomputeKey((k) => k + 1))
+    ro.observe(article)
+    if (typeof document !== 'undefined' && document.fonts) {
+      document.fonts.ready.then(() => setRecomputeKey((k) => k + 1)).catch(() => {})
+    }
+    window.addEventListener('resize', () => setRecomputeKey((k) => k + 1))
+    return () => ro.disconnect()
+  }, [])
+
+  // Handlers — keep optimistic UI: append/update local state, server is source on next reload
+  const handleAddComment = useCallback(() => {
+    const sel = document.getSelection()
+    if (!sel || sel.rangeCount === 0 || sel.isCollapsed) return
+    const range = sel.getRangeAt(0)
+    const article = articleRef.current
+    if (!article) return
+    const anchor = rangeToAnchor(range, article)
+    if (!anchor) return
+    setPending(anchor)
+    sel.removeAllRanges()
+  }, [])
+
+  const handleSubmitNew = useCallback(
+    async (body: string, authorName: string | null) => {
+      if (!pending) return
+      try {
+        const { highlight } = await createHighlight(postId, {
+          anchor: pending,
+          body,
+          authorName,
+        })
+        setHighlights((prev) => [...prev, highlight])
+        setPending(null)
+        setError(null)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to comment')
+        throw err
+      }
+    },
+    [pending, postId],
+  )
+
+  const handleReply = useCallback(
+    async (highlightId: string, parentId: string | null, body: string, authorName: string | null) => {
+      const { comment } = await createReply(postId, highlightId, { parentId, body, authorName })
+      setHighlights((prev) =>
+        prev.map((h) => (h.id === highlightId ? { ...h, thread: [...h.thread, comment] } : h)),
+      )
+    },
+    [postId],
+  )
+
+  const handleReact = useCallback(
+    async (highlightId: string, commentId: string, emoji: string) => {
+      const { reactions } = await toggleReaction(postId, highlightId, commentId, emoji)
+      setHighlights((prev) =>
+        prev.map((h) =>
+          h.id === highlightId
+            ? {
+                ...h,
+                thread: h.thread.map((c) => (c.id === commentId ? { ...c, reactions } : c)),
+              }
+            : h,
+        ),
+      )
+    },
+    [postId],
+  )
+
+  const handleResolve = useCallback(
+    async (highlightId: string, resolved: boolean) => {
+      const { highlight } = await setHighlightResolved(postId, highlightId, resolved)
+      setHighlights((prev) => prev.map((h) => (h.id === highlightId ? highlight : h)))
+    },
+    [postId],
+  )
+
+  const handleDelete = useCallback(
+    async (highlightId: string, commentId?: string) => {
+      if (commentId) {
+        const res = await deleteComment(postId, highlightId, commentId)
+        if (res.removedHighlight) {
+          setHighlights((prev) => prev.filter((h) => h.id !== highlightId))
+        } else {
+          setHighlights((prev) =>
+            prev.map((h) =>
+              h.id === highlightId
+                ? { ...h, thread: h.thread.filter((c) => c.id !== commentId) }
+                : h,
+            ),
+          )
+        }
+      } else {
+        await deleteHighlight(postId, highlightId)
+        setHighlights((prev) => prev.filter((h) => h.id !== highlightId))
+      }
+    },
+    [postId],
+  )
+
+  const article = articleRef.current
+
+  return (
+    <div className='relative mx-auto w-full max-w-7xl'>
+      <div ref={articleRef} className='relative'>
+        {children}
+        {highlights.map((h) => (
+          <HighlightMark
+            key={h.id}
+            highlight={h}
+            articleEl={article}
+            recomputeKey={recomputeKey}
+          />
+        ))}
+        <SelectionToolbar
+          containerRef={articleRef}
+          onAddComment={handleAddComment}
+          suppressed={!!pending}
+        />
+      </div>
+
+      {/* Composer — appears in the rail when a new highlight is being drafted. */}
+      <aside className='pointer-events-none absolute right-0 top-0 hidden w-72 lg:block'>
+        <div className='pointer-events-auto sticky top-4 max-h-[calc(100vh-2rem)] overflow-y-auto pl-4'>
+          {pending && (
+            <div className='mb-3 rounded-lg border-2 border-amber-300 bg-amber-50/40 p-2'>
+              <div className='mb-2 text-xs text-amber-900'>
+                Commenting on “{pending.exact.slice(0, 40)}{pending.exact.length > 40 ? '…' : ''}”
+              </div>
+              <CommentComposer
+                placeholder='Add a comment…'
+                submitLabel='Comment'
+                onSubmit={handleSubmitNew}
+                onCancel={() => setPending(null)}
+              />
+            </div>
+          )}
+          {error && (
+            <div className='mb-2 rounded border border-red-200 bg-red-50 p-2 text-xs text-red-700'>
+              {error}
+            </div>
+          )}
+          <CommentRail
+            highlights={highlights}
+            articleEl={article}
+            recomputeKey={recomputeKey}
+            fingerprint={fingerprint}
+            isOwner={isOwner}
+            onReply={handleReply}
+            onReact={handleReact}
+            onResolve={handleResolve}
+            onDelete={handleDelete}
+          />
+        </div>
+      </aside>
+
+      {/* Mobile fallback: bottom sheet for any active composer or thread.
+          Phase 8 will flesh out — for v1 we tap into the same components. */}
+      {pending && (
+        <div className='fixed inset-x-0 bottom-0 z-50 border-t border-amber-200 bg-white p-3 shadow-lg lg:hidden'>
+          <div className='mx-auto max-w-3xl'>
+            <div className='mb-2 text-xs text-amber-900'>
+              Commenting on “{pending.exact.slice(0, 40)}{pending.exact.length > 40 ? '…' : ''}”
+            </div>
+            <CommentComposer
+              placeholder='Add a comment…'
+              submitLabel='Comment'
+              onSubmit={handleSubmitNew}
+              onCancel={() => setPending(null)}
+            />
+          </div>
+        </div>
+      )}
+
+      {/* Mobile: existing highlights as a stacked list under the article. */}
+      {highlights.length > 0 && (
+        <div className='mt-6 space-y-3 px-4 lg:hidden'>
+          <h2 className='text-sm font-semibold text-gray-700'>Inline comments</h2>
+          {highlights.map((h) => (
+            <CommentCard
+              key={h.id}
+              highlight={h}
+              fingerprint={fingerprint}
+              isOwner={isOwner}
+              onReply={handleReply}
+              onReact={handleReact}
+              onResolve={handleResolve}
+              onDelete={handleDelete}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/Highlights/HighlightMark.tsx
+++ b/components/Highlights/HighlightMark.tsx
@@ -1,0 +1,80 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+import { anchorToRange } from '@/lib/highlights/anchoring'
+import { Highlight } from '@/lib/highlights/schema'
+import { setFocused, useFocusedHighlight } from '@/lib/highlights/syncFocus'
+
+interface HighlightMarkProps {
+  highlight: Highlight
+  articleEl: HTMLElement | null
+  /** Trigger to recompute rects (article resize, font load, etc.). */
+  recomputeKey?: number
+}
+
+interface OverlayRect {
+  top: number
+  left: number
+  width: number
+  height: number
+}
+
+/**
+ * Renders the visual highlight by overlaying absolutely-positioned divs over
+ * each `Range.getClientRects()` of the resolved anchor. Doesn't modify the
+ * article DOM — non-invasive overlay.
+ */
+export function HighlightMark({ highlight, articleEl, recomputeKey = 0 }: HighlightMarkProps) {
+  const [rects, setRects] = useState<OverlayRect[]>([])
+  const focused = useFocusedHighlight()
+
+  useEffect(() => {
+    if (!articleEl) return
+    const range = anchorToRange(highlight.anchor, articleEl)
+    if (!range) {
+      setRects([])
+      return
+    }
+    const articleRect = articleEl.getBoundingClientRect()
+    const next = Array.from(range.getClientRects()).map((r) => ({
+      top: r.top - articleRect.top + articleEl.scrollTop,
+      left: r.left - articleRect.left,
+      width: r.width,
+      height: r.height,
+    }))
+    setRects(next)
+  }, [highlight.anchor, articleEl, recomputeKey])
+
+  if (rects.length === 0) return null
+  const isFocused = focused === highlight.id
+  const isResolved = highlight.resolved
+
+  return (
+    <>
+      {rects.map((r, i) => (
+        <button
+          key={`${highlight.id}-${i}`}
+          type='button'
+          aria-label={`Highlight: ${highlight.thread[0]?.body.slice(0, 80) ?? ''}`}
+          data-highlight-id={highlight.id}
+          onClick={(e) => {
+            e.preventDefault()
+            e.stopPropagation()
+            setFocused(isFocused ? null : highlight.id)
+          }}
+          onMouseEnter={() => setFocused(highlight.id)}
+          style={{ top: r.top, left: r.left, width: r.width, height: r.height }}
+          className={[
+            'absolute z-10 cursor-pointer rounded-sm border-b-2 transition-colors',
+            isResolved
+              ? 'bg-gray-200/30 border-gray-300/60 hover:bg-gray-200/50'
+              : 'bg-amber-200/40 border-amber-300/70 hover:bg-amber-200/70',
+            isFocused && !isResolved ? 'bg-amber-300/60 border-amber-500' : '',
+            isFocused && isResolved ? 'bg-gray-300/60 border-gray-500' : '',
+          ].join(' ')}
+        />
+      ))}
+    </>
+  )
+}

--- a/components/Highlights/Reactions.tsx
+++ b/components/Highlights/Reactions.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import { Reactions as ReactionsT } from '@/lib/highlights/schema'
+
+const QUICK_EMOJI = ['👍', '❤️', '🎉', '🤔', '👀'] as const
+
+interface ReactionsProps {
+  reactions: ReactionsT
+  fingerprint: string | null
+  onToggle: (emoji: string) => void
+  disabled?: boolean
+}
+
+export function Reactions({ reactions, fingerprint, onToggle, disabled }: ReactionsProps) {
+  return (
+    <div className='flex flex-wrap items-center gap-1'>
+      {QUICK_EMOJI.map((emoji) => {
+        const fps = reactions[emoji] ?? []
+        const count = fps.length
+        const reacted = fingerprint != null && fps.includes(fingerprint)
+        return (
+          <button
+            key={emoji}
+            type='button'
+            onClick={() => onToggle(emoji)}
+            disabled={disabled}
+            className={[
+              'inline-flex h-6 items-center gap-1 rounded-full border px-1.5 text-[11px] transition-colors',
+              reacted
+                ? 'border-amber-300 bg-amber-50 text-amber-900'
+                : 'border-gray-200 bg-white text-gray-600 hover:bg-gray-50',
+              disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer',
+            ].join(' ')}
+            aria-pressed={reacted}
+            aria-label={`React with ${emoji}`}
+          >
+            <span>{emoji}</span>
+            {count > 0 && <span>{count}</span>}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/components/Highlights/SelectionToolbar.tsx
+++ b/components/Highlights/SelectionToolbar.tsx
@@ -1,0 +1,89 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { MessageSquarePlus } from 'lucide-react'
+
+interface Position {
+  top: number
+  left: number
+}
+
+interface SelectionToolbarProps {
+  /** Container ref the toolbar should anchor to (article wrapper). */
+  containerRef: React.RefObject<HTMLElement>
+  onAddComment: () => void
+  /** When true, the toolbar is hidden (e.g. composer is open). */
+  suppressed?: boolean
+}
+
+/**
+ * Floating "+ Comment" button that appears in the right gutter of the
+ * article when the user has an active text selection. Position tracks
+ * the top of the selection rect, mirroring Google Docs' margin "+" UX.
+ */
+export function SelectionToolbar({ containerRef, onAddComment, suppressed }: SelectionToolbarProps) {
+  const [pos, setPos] = useState<Position | null>(null)
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+
+    function update() {
+      if (suppressed) {
+        setPos(null)
+        return
+      }
+      const sel = document.getSelection()
+      if (!sel || sel.isCollapsed || sel.rangeCount === 0) {
+        setPos(null)
+        return
+      }
+      const range = sel.getRangeAt(0)
+      const containerEl = containerRef.current
+      if (!containerEl) return
+      if (!containerEl.contains(range.startContainer) || !containerEl.contains(range.endContainer)) {
+        setPos(null)
+        return
+      }
+
+      const rect = range.getBoundingClientRect()
+      const containerRect = containerEl.getBoundingClientRect()
+      if (rect.width === 0 && rect.height === 0) {
+        setPos(null)
+        return
+      }
+      // Top of selection, right gutter of the container.
+      setPos({
+        top: rect.top - containerRect.top,
+        left: containerRect.width + 8,
+      })
+    }
+
+    const onSelectionChange = () => update()
+    document.addEventListener('selectionchange', onSelectionChange)
+    window.addEventListener('resize', onSelectionChange)
+    return () => {
+      document.removeEventListener('selectionchange', onSelectionChange)
+      window.removeEventListener('resize', onSelectionChange)
+    }
+  }, [containerRef, suppressed])
+
+  if (!pos) return null
+
+  return (
+    <button
+      type='button'
+      onMouseDown={(e) => {
+        // Don't blur the selection when clicking — we still need it for
+        // anchor capture inside `onAddComment`.
+        e.preventDefault()
+      }}
+      onClick={onAddComment}
+      style={{ top: pos.top, left: pos.left }}
+      className='absolute z-30 flex h-8 w-8 items-center justify-center rounded-full bg-amber-400 text-white shadow-md transition-all hover:scale-110 hover:bg-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-300'
+      aria-label='Add comment on selection'
+    >
+      <MessageSquarePlus className='h-4 w-4' />
+    </button>
+  )
+}

--- a/lib/highlights/anchoring.ts
+++ b/lib/highlights/anchoring.ts
@@ -1,0 +1,209 @@
+/**
+ * Range ↔ HighlightAnchor conversion.
+ *
+ * Anchoring strategy is a simplified W3C Web Annotation:
+ *   - TextPositionSelector (startOffset/endOffset) for the fast path
+ *   - TextQuoteSelector (prefix/exact/suffix) for the resilient path
+ *   - Final fallback: bare exact text (may resolve to wrong occurrence
+ *     if duplicated, so prefix/suffix are the primary disambiguator)
+ *
+ * All offsets are character offsets within `articleEl.textContent`. The same
+ * text-collection rule applies to capture and restore, so DOM structure
+ * changes (e.g. wrapping a span) don't break the anchor as long as the text
+ * content matches.
+ */
+
+import type { HighlightAnchor } from './schema'
+
+const CONTEXT_WINDOW = 32
+
+/**
+ * Build a `HighlightAnchor` from a live DOM `Range` inside `articleEl`.
+ *
+ * Returns `null` when the range is collapsed, lies outside the article, or
+ * cannot be resolved into char offsets.
+ */
+export function rangeToAnchor(range: Range, articleEl: HTMLElement): HighlightAnchor | null {
+  if (range.collapsed) return null
+
+  if (!articleEl.contains(range.startContainer) || !articleEl.contains(range.endContainer)) {
+    return null
+  }
+
+  const articleText = articleEl.textContent ?? ''
+  if (articleText.length === 0) return null
+
+  const startOffset = computeOffset(articleEl, range.startContainer, range.startOffset)
+  const endOffset = computeOffset(articleEl, range.endContainer, range.endOffset)
+  if (startOffset < 0 || endOffset < 0 || endOffset <= startOffset) return null
+
+  const exact = articleText.slice(startOffset, endOffset)
+  if (exact.length === 0) return null
+
+  const prefix = articleText.slice(Math.max(0, startOffset - CONTEXT_WINDOW), startOffset)
+  const suffix = articleText.slice(endOffset, Math.min(articleText.length, endOffset + CONTEXT_WINDOW))
+
+  return { startOffset, endOffset, exact, prefix, suffix }
+}
+
+/**
+ * Resolve a `HighlightAnchor` against `articleEl` and return a live `Range`.
+ *
+ * Strategy:
+ *   1. Fast path — if the anchor's offsets still slice to `exact`, use them.
+ *   2. Resilient path — search for `prefix + exact + suffix` and offset back.
+ *   3. Last resort — search for `exact` alone.
+ *   4. Otherwise — return `null` (caller treats as orphaned).
+ */
+export function anchorToRange(anchor: HighlightAnchor, articleEl: HTMLElement): Range | null {
+  const articleText = articleEl.textContent ?? ''
+  if (articleText.length === 0) return null
+
+  // 1. Fast path
+  if (
+    anchor.startOffset >= 0 &&
+    anchor.endOffset <= articleText.length &&
+    articleText.slice(anchor.startOffset, anchor.endOffset) === anchor.exact
+  ) {
+    return rangeFromOffsets(articleEl, anchor.startOffset, anchor.endOffset)
+  }
+
+  // 2. Resilient path — combined prefix + exact + suffix
+  if (anchor.prefix.length > 0 || anchor.suffix.length > 0) {
+    const needle = anchor.prefix + anchor.exact + anchor.suffix
+    const idx = articleText.indexOf(needle)
+    if (idx >= 0) {
+      const start = idx + anchor.prefix.length
+      return rangeFromOffsets(articleEl, start, start + anchor.exact.length)
+    }
+  }
+
+  // 3. Last resort — exact alone (first occurrence)
+  if (anchor.exact.length > 0) {
+    const idx = articleText.indexOf(anchor.exact)
+    if (idx >= 0) {
+      return rangeFromOffsets(articleEl, idx, idx + anchor.exact.length)
+    }
+  }
+
+  // 4. Orphaned
+  return null
+}
+
+/**
+ * Walk `root` (text nodes only) accumulating character lengths until we reach
+ * the (`node`, `nodeOffset`) boundary. Returns the cumulative offset within
+ * `root.textContent`, or -1 if the boundary can't be located.
+ *
+ * Handles two cases:
+ *   - `node` is a text node — accumulate up to `node`, then add `nodeOffset`.
+ *   - `node` is an element — accumulate text length of the element's
+ *     children up to index `nodeOffset`, then add their text length to the
+ *     cumulative offset that lands on the element.
+ */
+function computeOffset(root: HTMLElement, node: Node, nodeOffset: number): number {
+  if (node.nodeType === Node.TEXT_NODE) {
+    return offsetToTextNode(root, node, nodeOffset)
+  }
+
+  if (node === root) {
+    // Range boundary on the article element itself: nodeOffset indexes children.
+    return offsetThroughChildren(root, root, nodeOffset)
+  }
+
+  if (node.nodeType === Node.ELEMENT_NODE) {
+    return offsetThroughChildren(root, node as Element, nodeOffset)
+  }
+
+  return -1
+}
+
+/** Offset within `root.textContent` of `(textNode, charOffsetWithinNode)`. */
+function offsetToTextNode(root: HTMLElement, textNode: Node, charOffsetWithinNode: number): number {
+  const ownerDoc = root.ownerDocument
+  if (!ownerDoc) return -1
+
+  let offset = 0
+  const walker = ownerDoc.createTreeWalker(root, NodeFilter.SHOW_TEXT)
+  let current: Node | null = walker.nextNode()
+  while (current) {
+    if (current === textNode) {
+      const len = current.textContent?.length ?? 0
+      return offset + Math.min(charOffsetWithinNode, len)
+    }
+    offset += current.textContent?.length ?? 0
+    current = walker.nextNode()
+  }
+  return -1
+}
+
+/**
+ * Offset within `root.textContent` of "the boundary right before child #
+ * `childIndex` of `el`". Used when a Range boundary lands on an Element
+ * rather than a text node.
+ */
+function offsetThroughChildren(root: HTMLElement, el: Element, childIndex: number): number {
+  // Sum text length of el's first `childIndex` children.
+  let internalLen = 0
+  for (let i = 0; i < childIndex && i < el.childNodes.length; i++) {
+    internalLen += el.childNodes[i].textContent?.length ?? 0
+  }
+
+  if (el === root) {
+    // Boundary is at root level — we're done, internalLen IS the offset.
+    return internalLen
+  }
+
+  // Otherwise we need cumulative offset up to `el`, then add `internalLen`.
+  const ownerDoc = root.ownerDocument
+  if (!ownerDoc) return -1
+
+  let offset = 0
+  const walker = ownerDoc.createTreeWalker(root, NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_TEXT)
+  let current: Node | null = walker.nextNode()
+  while (current) {
+    if (current === el) {
+      return offset + internalLen
+    }
+    if (current.nodeType === Node.TEXT_NODE) {
+      offset += current.textContent?.length ?? 0
+    }
+    current = walker.nextNode()
+  }
+  return -1
+}
+
+/** Build a `Range` covering `[start, end)` char offsets within `root.textContent`. */
+function rangeFromOffsets(root: HTMLElement, start: number, end: number): Range | null {
+  const ownerDoc = root.ownerDocument
+  if (!ownerDoc) return null
+  if (start < 0 || end < start) return null
+
+  const range = ownerDoc.createRange()
+  let cursor = 0
+  let startSet = false
+  let endSet = false
+
+  const walker = ownerDoc.createTreeWalker(root, NodeFilter.SHOW_TEXT)
+  let node: Node | null = walker.nextNode()
+  while (node) {
+    const len = node.textContent?.length ?? 0
+    const nodeStart = cursor
+    const nodeEnd = cursor + len
+
+    if (!startSet && start >= nodeStart && start <= nodeEnd) {
+      range.setStart(node, start - nodeStart)
+      startSet = true
+    }
+    if (!endSet && end >= nodeStart && end <= nodeEnd) {
+      range.setEnd(node, end - nodeStart)
+      endSet = true
+    }
+    if (startSet && endSet) return range
+
+    cursor = nodeEnd
+    node = walker.nextNode()
+  }
+
+  return startSet && endSet ? range : null
+}

--- a/lib/highlights/cardLayout.ts
+++ b/lib/highlights/cardLayout.ts
@@ -1,0 +1,28 @@
+/**
+ * Constraint solver for Google Docs-style comment cards.
+ *
+ * Each card has a "preferred top" (its anchor's vertical position in the
+ * article) and a measured height. The solver walks them in preferred-top
+ * order and pushes overlapping cards down so adjacent cards never collide.
+ *
+ * Pure function — easy to unit-test, easy to inline in `<CommentRail>` via
+ * a hook.
+ */
+
+export interface CardSpec {
+  id: string
+  desiredTop: number
+  height: number
+}
+
+export function solveCardLayout(specs: readonly CardSpec[], gap = 8): Map<string, number> {
+  const sorted = [...specs].sort((a, b) => a.desiredTop - b.desiredTop)
+  const tops = new Map<string, number>()
+  let stackTop = 0
+  for (const spec of sorted) {
+    const top = Math.max(spec.desiredTop, stackTop)
+    tops.set(spec.id, top)
+    stackTop = top + spec.height + gap
+  }
+  return tops
+}

--- a/lib/highlights/clientApi.ts
+++ b/lib/highlights/clientApi.ts
@@ -1,0 +1,110 @@
+/**
+ * Client-side API for inline highlights. Thin wrapper over fetch with
+ * `ApiResponse<T>` envelope handling.
+ */
+
+import {
+  Highlight,
+  InlineComment,
+  PostHighlights,
+  Reactions,
+} from './schema'
+
+interface ApiResponse<T> {
+  success: boolean
+  data?: T
+  error?: string
+}
+
+async function request<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, {
+    ...init,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(init?.headers ?? {}),
+    },
+  })
+  const body = (await res.json()) as ApiResponse<T>
+  if (!res.ok || !body.success || body.data === undefined) {
+    throw new Error(body.error ?? `Request failed: ${res.status}`)
+  }
+  return body.data
+}
+
+export interface HighlightsLoadResponse extends PostHighlights {
+  currentFingerprint: string
+  isOwner: boolean
+}
+
+export async function fetchHighlights(postId: string): Promise<HighlightsLoadResponse> {
+  return request<HighlightsLoadResponse>(`/api/blog/${encodeURIComponent(postId)}/highlights`)
+}
+
+export async function createHighlight(
+  postId: string,
+  payload: {
+    anchor: Highlight['anchor']
+    body: string
+    authorName?: string | null
+  },
+): Promise<{ highlight: Highlight }> {
+  return request(`/api/blog/${encodeURIComponent(postId)}/highlights`, {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  })
+}
+
+export async function createReply(
+  postId: string,
+  highlightId: string,
+  payload: { parentId?: string | null; body: string; authorName?: string | null },
+): Promise<{ comment: InlineComment }> {
+  return request(
+    `/api/blog/${encodeURIComponent(postId)}/highlights/${encodeURIComponent(highlightId)}/replies`,
+    { method: 'POST', body: JSON.stringify(payload) },
+  )
+}
+
+export async function toggleReaction(
+  postId: string,
+  highlightId: string,
+  commentId: string,
+  emoji: string,
+): Promise<{ reactions: Reactions }> {
+  return request(
+    `/api/blog/${encodeURIComponent(postId)}/highlights/${encodeURIComponent(highlightId)}/comments/${encodeURIComponent(commentId)}/reactions`,
+    { method: 'POST', body: JSON.stringify({ emoji }) },
+  )
+}
+
+export async function setHighlightResolved(
+  postId: string,
+  highlightId: string,
+  resolved: boolean,
+): Promise<{ highlight: Highlight }> {
+  return request(
+    `/api/blog/${encodeURIComponent(postId)}/highlights/${encodeURIComponent(highlightId)}/resolve`,
+    { method: 'POST', body: JSON.stringify({ resolved }) },
+  )
+}
+
+export async function deleteHighlight(
+  postId: string,
+  highlightId: string,
+): Promise<{ ok: boolean }> {
+  return request(
+    `/api/blog/${encodeURIComponent(postId)}/highlights/${encodeURIComponent(highlightId)}`,
+    { method: 'DELETE' },
+  )
+}
+
+export async function deleteComment(
+  postId: string,
+  highlightId: string,
+  commentId: string,
+): Promise<{ ok: boolean; removedHighlight?: boolean }> {
+  return request(
+    `/api/blog/${encodeURIComponent(postId)}/highlights/${encodeURIComponent(highlightId)}/comments/${encodeURIComponent(commentId)}`,
+    { method: 'DELETE' },
+  )
+}

--- a/lib/highlights/highlightsRepo.ts
+++ b/lib/highlights/highlightsRepo.ts
@@ -1,0 +1,268 @@
+/**
+ * Storage layer for inline highlight comments.
+ *
+ * Storage shape: one JSON file per post at `data/highlights/<post-slug>.json`,
+ * structured as a `PostHighlights` blob.
+ *
+ * Two backends:
+ *   - `LocalFsHighlightsRepo` for `NODE_ENV=development` (writes to disk
+ *     under the repo root, mirroring how `localClient.server.ts` works for
+ *     posts).
+ *   - `GitHubHighlightsRepo` for production (writes via Octokit with
+ *     SHA-based optimistic concurrency and bounded retries).
+ *
+ * In production, anonymous writes need a service token because there's no
+ * user session. Set `HIGHLIGHTS_GH_TOKEN` (a fine-grained PAT or GitHub App
+ * token with `contents:write` on the Cofe repo). Owner-moderation routes
+ * can pass the logged-in user's session token instead via `ownerToken`.
+ *
+ * Reads are cached in-memory for 30 s to keep GitHub reads off the hot path.
+ */
+
+import { promises as fs } from 'fs'
+import path from 'path'
+import { Octokit } from '@octokit/rest'
+
+import {
+  PostHighlights,
+  PostHighlightsSchema,
+  emptyPostHighlights,
+} from './schema'
+
+const REPO = 'Cofe'
+const FILE_DIR = 'data/highlights'
+const CACHE_TTL_MS = 30_000
+const SAVE_RETRY_LIMIT = 3
+const SAFE_POST_ID = /^[a-zA-Z0-9._-]+$/
+
+export interface LoadedHighlights {
+  data: PostHighlights
+  /** GitHub blob SHA, or `null` for files that don't exist yet / dev mode. */
+  sha: string | null
+}
+
+export interface SaveResult {
+  sha: string
+}
+
+export interface HighlightsRepo {
+  load(postId: string): Promise<LoadedHighlights>
+  save(
+    postId: string,
+    data: PostHighlights,
+    expectedSha: string | null,
+    commitMessage: string,
+  ): Promise<SaveResult>
+}
+
+interface CacheEntry {
+  data: PostHighlights
+  sha: string | null
+  expiresAt: number
+}
+
+/** Module-scope cache shared across repo instances. */
+const cache = new Map<string, CacheEntry>()
+
+export function clearHighlightsCache(): void {
+  cache.clear()
+}
+
+function pathFor(postId: string): string {
+  return `${FILE_DIR}/${postId}.json`
+}
+
+function assertSafePostId(postId: string): void {
+  if (!SAFE_POST_ID.test(postId)) {
+    throw new Error(`Invalid postId: ${postId}`)
+  }
+}
+
+function getStatus(err: unknown): number | undefined {
+  if (typeof err === 'object' && err !== null && 'status' in err) {
+    const s = (err as { status?: unknown }).status
+    return typeof s === 'number' ? s : undefined
+  }
+  return undefined
+}
+
+/** Minimal Octokit shape we depend on — keeps tests injectable. */
+export interface OctokitLike {
+  repos: {
+    getContent: (params: { owner: string; repo: string; path: string }) => Promise<{
+      data: unknown
+    }>
+    createOrUpdateFileContents: (params: {
+      owner: string
+      repo: string
+      path: string
+      message: string
+      content: string
+      sha?: string
+    }) => Promise<{
+      data: { content?: { sha?: string } | null }
+    }>
+  }
+}
+
+export class LocalFsHighlightsRepo implements HighlightsRepo {
+  constructor(private rootDir: string) {}
+
+  private absPath(postId: string): string {
+    return path.join(this.rootDir, FILE_DIR, `${postId}.json`)
+  }
+
+  async load(postId: string): Promise<LoadedHighlights> {
+    assertSafePostId(postId)
+    try {
+      const text = await fs.readFile(this.absPath(postId), 'utf-8')
+      const parsed = PostHighlightsSchema.parse(JSON.parse(text))
+      return { data: parsed, sha: null }
+    } catch (err: unknown) {
+      const code = (err as { code?: string })?.code
+      if (code === 'ENOENT') {
+        return { data: emptyPostHighlights(postId), sha: null }
+      }
+      throw err
+    }
+  }
+
+  async save(
+    postId: string,
+    data: PostHighlights,
+    expectedSha: string | null,
+    commitMessage: string,
+  ): Promise<SaveResult> {
+    void expectedSha // local FS has no concurrency
+    void commitMessage // local FS has no commit metadata
+    assertSafePostId(postId)
+    const validated = PostHighlightsSchema.parse(data)
+    const filePath = this.absPath(postId)
+    await fs.mkdir(path.dirname(filePath), { recursive: true })
+    await fs.writeFile(filePath, JSON.stringify(validated, null, 2), 'utf-8')
+    return { sha: '' }
+  }
+}
+
+export class GitHubHighlightsRepo implements HighlightsRepo {
+  constructor(private octokit: OctokitLike, private owner: string) {}
+
+  async load(postId: string): Promise<LoadedHighlights> {
+    assertSafePostId(postId)
+
+    const cached = cache.get(postId)
+    if (cached && cached.expiresAt > Date.now()) {
+      return { data: cached.data, sha: cached.sha }
+    }
+
+    const file = await this.readFile(postId)
+    if (!file) {
+      const empty = emptyPostHighlights(postId)
+      cache.set(postId, { data: empty, sha: null, expiresAt: Date.now() + CACHE_TTL_MS })
+      return { data: empty, sha: null }
+    }
+
+    const parsed = PostHighlightsSchema.parse(JSON.parse(file.content))
+    cache.set(postId, { data: parsed, sha: file.sha, expiresAt: Date.now() + CACHE_TTL_MS })
+    return { data: parsed, sha: file.sha }
+  }
+
+  async save(
+    postId: string,
+    data: PostHighlights,
+    expectedSha: string | null,
+    commitMessage: string,
+  ): Promise<SaveResult> {
+    assertSafePostId(postId)
+    const validated = PostHighlightsSchema.parse(data)
+    const content = Buffer.from(JSON.stringify(validated, null, 2)).toString('base64')
+
+    let attempt = 0
+    let currentSha: string | null = expectedSha
+
+    while (attempt < SAVE_RETRY_LIMIT) {
+      try {
+        const res = await this.octokit.repos.createOrUpdateFileContents({
+          owner: this.owner,
+          repo: REPO,
+          path: pathFor(postId),
+          message: commitMessage,
+          content,
+          ...(currentSha ? { sha: currentSha } : {}),
+        })
+        const newSha = res.data.content?.sha ?? ''
+        cache.set(postId, { data: validated, sha: newSha, expiresAt: Date.now() + CACHE_TTL_MS })
+        return { sha: newSha }
+      } catch (err: unknown) {
+        const status = getStatus(err)
+        if (status === 409 || status === 422) {
+          // Concurrent write — drop cache, re-read SHA, retry.
+          cache.delete(postId)
+          attempt++
+          const fresh = await this.readFile(postId)
+          currentSha = fresh?.sha ?? null
+          continue
+        }
+        throw err
+      }
+    }
+
+    throw new Error(`Save failed after ${SAVE_RETRY_LIMIT} retries due to write contention`)
+  }
+
+  private async readFile(postId: string): Promise<{ content: string; sha: string } | null> {
+    try {
+      const res = await this.octokit.repos.getContent({
+        owner: this.owner,
+        repo: REPO,
+        path: pathFor(postId),
+      })
+      const data = res.data as
+        | { type?: string; content?: string; sha?: string; encoding?: string }
+        | unknown[]
+      if (Array.isArray(data) || (data as { type?: string }).type !== 'file') {
+        return null
+      }
+      const file = data as { content: string; sha: string }
+      return {
+        content: Buffer.from(file.content, 'base64').toString('utf-8'),
+        sha: file.sha,
+      }
+    } catch (err: unknown) {
+      if (getStatus(err) === 404) return null
+      throw err
+    }
+  }
+}
+
+export interface GetRepoOptions {
+  /** Override token (e.g. logged-in owner moderation flow). Falls back to env. */
+  ownerToken?: string
+}
+
+/**
+ * Pick a `HighlightsRepo` for the current environment.
+ *
+ * Throws if production env vars are missing, so the API route surfaces a
+ * clear error rather than silently failing the way `updateLikes` does.
+ */
+export function getHighlightsRepo(opts: GetRepoOptions = {}): HighlightsRepo {
+  const isDev = process.env.NODE_ENV === 'development'
+  if (isDev && typeof window === 'undefined') {
+    return new LocalFsHighlightsRepo(process.cwd())
+  }
+
+  const token = opts.ownerToken ?? process.env.HIGHLIGHTS_GH_TOKEN
+  if (!token) {
+    throw new Error(
+      'HIGHLIGHTS_GH_TOKEN not configured. Inline comments require a service token in production.',
+    )
+  }
+
+  const owner = process.env.GITHUB_USERNAME
+  if (!owner) {
+    throw new Error('GITHUB_USERNAME not configured.')
+  }
+
+  return new GitHubHighlightsRepo(new Octokit({ auth: token }), owner)
+}

--- a/lib/highlights/highlightsRepo.ts
+++ b/lib/highlights/highlightsRepo.ts
@@ -33,7 +33,7 @@ const REPO = 'Cofe'
 const FILE_DIR = 'data/highlights'
 const CACHE_TTL_MS = 30_000
 const SAVE_RETRY_LIMIT = 3
-const SAFE_POST_ID = /^[a-zA-Z0-9._-]+$/
+const MAX_POST_ID_LENGTH = 200
 
 export interface LoadedHighlights {
   data: PostHighlights
@@ -73,7 +73,21 @@ function pathFor(postId: string): string {
 }
 
 function assertSafePostId(postId: string): void {
-  if (!SAFE_POST_ID.test(postId)) {
+  // Reject empty / oversized — and any character or pattern that could
+  // escape `data/highlights/<postId>.json` to write somewhere else on
+  // disk or in the GitHub repo. We DON'T enforce an ASCII allowlist —
+  // the blog has CJK-titled posts (e.g. `我做了一款旅行记录应用：mile`)
+  // and we want them to work.
+  if (!postId || postId.length === 0 || postId.length > MAX_POST_ID_LENGTH) {
+    throw new Error(`Invalid postId: ${postId}`)
+  }
+  if (
+    postId.includes('/') ||
+    postId.includes('\\') ||
+    postId.includes('\x00') ||
+    postId.includes('..') ||
+    postId.startsWith('.')
+  ) {
     throw new Error(`Invalid postId: ${postId}`)
   }
 }

--- a/lib/highlights/rateLimit.ts
+++ b/lib/highlights/rateLimit.ts
@@ -1,0 +1,89 @@
+/**
+ * Sliding-window rate limiter.
+ *
+ * Used to throttle anonymous comment creation per fingerprint. Defaults are
+ * tuned for an inline-comments use case where heavy commenting is suspect:
+ *   - Comment / reply: 5 actions / 10 min
+ *   - Reaction toggle: 30 actions / 10 min
+ *
+ * Implementation: in-memory `Map<key, ring of timestamps>`. Per-instance, not
+ * cross-instance — good enough for a personal blog with a single Vercel
+ * function. Replace with Upstash Redis if traffic warrants.
+ */
+
+const COMMENT_BUCKET = Symbol('comment')
+const REACTION_BUCKET = Symbol('reaction')
+
+const buckets = new Map<symbol, Map<string, number[]>>()
+
+export interface RateLimitConfig {
+  max: number
+  windowMs: number
+}
+
+export interface RateLimitResult {
+  allowed: boolean
+  remaining: number
+  retryAfterMs: number
+}
+
+export const COMMENT_LIMIT: RateLimitConfig = { max: 5, windowMs: 10 * 60_000 }
+export const REACTION_LIMIT: RateLimitConfig = { max: 30, windowMs: 10 * 60_000 }
+
+export function checkCommentRateLimit(
+  key: string,
+  config: RateLimitConfig = COMMENT_LIMIT,
+  now: number = Date.now(),
+): RateLimitResult {
+  return checkRateLimit(COMMENT_BUCKET, key, config, now)
+}
+
+export function checkReactionRateLimit(
+  key: string,
+  config: RateLimitConfig = REACTION_LIMIT,
+  now: number = Date.now(),
+): RateLimitResult {
+  return checkRateLimit(REACTION_BUCKET, key, config, now)
+}
+
+export function clearAllRateLimits(): void {
+  buckets.clear()
+}
+
+function checkRateLimit(
+  scope: symbol,
+  key: string,
+  { max, windowMs }: RateLimitConfig,
+  now: number,
+): RateLimitResult {
+  const bucket = getOrCreate(scope)
+  const cutoff = now - windowMs
+  const stamps = (bucket.get(key) ?? []).filter((t) => t > cutoff)
+
+  if (stamps.length >= max) {
+    const oldestInWindow = stamps[0]
+    bucket.set(key, stamps)
+    return {
+      allowed: false,
+      remaining: 0,
+      retryAfterMs: Math.max(0, windowMs - (now - oldestInWindow)),
+    }
+  }
+
+  stamps.push(now)
+  bucket.set(key, stamps)
+  return {
+    allowed: true,
+    remaining: max - stamps.length,
+    retryAfterMs: 0,
+  }
+}
+
+function getOrCreate(scope: symbol): Map<string, number[]> {
+  let bucket = buckets.get(scope)
+  if (!bucket) {
+    bucket = new Map()
+    buckets.set(scope, bucket)
+  }
+  return bucket
+}

--- a/lib/highlights/schema.ts
+++ b/lib/highlights/schema.ts
@@ -1,0 +1,77 @@
+/**
+ * Zod schemas + inferred types for inline highlight comments.
+ *
+ * Storage shape: one JSON file per post at `data/highlights/<post-slug>.json`,
+ * structured as a `PostHighlights` blob.
+ */
+
+import { z } from 'zod'
+
+/**
+ * W3C Web Annotation-inspired anchor.
+ *
+ * Combines a TextPositionSelector (startOffset/endOffset, fast path) with a
+ * TextQuoteSelector (prefix/exact/suffix, resilient when offsets shift). On
+ * restore, callers should try offsets first, then fall back to the quote.
+ */
+export const HighlightAnchorSchema = z
+  .object({
+    startOffset: z.number().int().nonnegative(),
+    endOffset: z.number().int().nonnegative(),
+    exact: z.string().min(1).max(1000),
+    prefix: z.string().max(64),
+    suffix: z.string().max(64),
+  })
+  .refine((d) => d.endOffset >= d.startOffset, {
+    message: 'endOffset must be >= startOffset',
+  })
+
+export type HighlightAnchor = z.infer<typeof HighlightAnchorSchema>
+
+/** Reactions: emoji → array of fingerprints that reacted. */
+export const ReactionsSchema = z.record(z.string(), z.array(z.string()))
+
+export type Reactions = z.infer<typeof ReactionsSchema>
+
+export const PlatformSchema = z.enum(['ios', 'android', 'web'])
+export type Platform = z.infer<typeof PlatformSchema>
+
+export const InlineCommentSchema = z.object({
+  id: z.string().min(1).max(64),
+  parentId: z.string().min(1).max(64).nullable(),
+  body: z.string().min(1).max(2000),
+  authorName: z.string().max(40).nullable(),
+  fingerprint: z.string().min(1).max(128),
+  country: z.string().max(8),
+  platform: PlatformSchema,
+  reactions: ReactionsSchema,
+  resolved: z.boolean(),
+  createdAt: z.string().datetime(),
+  hidden: z.boolean(),
+  hiddenReason: z.string().max(200).optional(),
+})
+
+export type InlineComment = z.infer<typeof InlineCommentSchema>
+
+export const HighlightSchema = z.object({
+  id: z.string().min(1).max(64),
+  anchor: HighlightAnchorSchema,
+  thread: z.array(InlineCommentSchema).min(1),
+  resolved: z.boolean(),
+  createdAt: z.string().datetime(),
+})
+
+export type Highlight = z.infer<typeof HighlightSchema>
+
+export const PostHighlightsSchema = z.object({
+  postId: z.string().min(1),
+  highlights: z.array(HighlightSchema),
+  schemaVersion: z.literal(1),
+})
+
+export type PostHighlights = z.infer<typeof PostHighlightsSchema>
+
+/** Empty `PostHighlights` blob for a post that has no highlights yet. */
+export function emptyPostHighlights(postId: string): PostHighlights {
+  return { postId, highlights: [], schemaVersion: 1 }
+}

--- a/lib/highlights/server.ts
+++ b/lib/highlights/server.ts
@@ -1,0 +1,88 @@
+/**
+ * Server-side helpers shared by `app/api/blog/[id]/highlights/**` routes.
+ *
+ * Centralises:
+ *   - Anonymous fingerprinting (reused from `lib/likeUtils.ts`)
+ *   - Owner authentication via NextAuth
+ *   - Standard `ApiResponse<T>` envelope
+ *   - Validation primitives
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+
+import {
+  createUserFingerprint,
+  detectPlatform,
+  getClientIP,
+  getLocationFromHeaders,
+  hashIP,
+} from '@/lib/likeUtils'
+import { getSession } from '@/lib/auth'
+import { Platform } from './schema'
+
+export interface ApiResponse<T> {
+  success: boolean
+  data?: T
+  error?: string
+}
+
+export function apiOk<T>(data: T, init?: ResponseInit): NextResponse<ApiResponse<T>> {
+  return NextResponse.json<ApiResponse<T>>({ success: true, data }, init)
+}
+
+export function apiError(message: string, status = 400): NextResponse<ApiResponse<never>> {
+  return NextResponse.json<ApiResponse<never>>({ success: false, error: message }, { status })
+}
+
+export interface RequestIdentity {
+  fingerprint: string
+  country: string
+  platform: Platform
+}
+
+export function extractIdentity(request: NextRequest): RequestIdentity {
+  const ip = getClientIP(request)
+  const location = getLocationFromHeaders(request)
+  const hashedIP = hashIP(ip)
+  const fingerprint = createUserFingerprint(hashedIP, location)
+  return {
+    fingerprint,
+    country: location.country,
+    platform: detectPlatform(location.userAgent) as Platform,
+  }
+}
+
+export async function isOwner(): Promise<boolean> {
+  const session = await getSession()
+  const owner = process.env.GITHUB_USERNAME
+  if (!session?.user?.username || !owner) return false
+  return session.user.username === owner
+}
+
+export async function getOwnerToken(): Promise<string | undefined> {
+  const session = await getSession()
+  return session?.accessToken
+}
+
+/**
+ * Parse + validate JSON body. Returns the parsed value, or throws an
+ * `ApiBodyError` with a useful message that callers can convert to 400.
+ */
+export class ApiBodyError extends Error {}
+
+export async function parseBody<T>(request: NextRequest, schema: z.ZodType<T>): Promise<T> {
+  let raw: unknown
+  try {
+    raw = await request.json()
+  } catch {
+    throw new ApiBodyError('Invalid JSON body')
+  }
+  const result = schema.safeParse(raw)
+  if (!result.success) {
+    throw new ApiBodyError(
+      result.error.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join('; '),
+    )
+  }
+  return result.data
+}

--- a/lib/highlights/syncFocus.ts
+++ b/lib/highlights/syncFocus.ts
@@ -1,0 +1,36 @@
+/**
+ * Lightweight pub-sub for highlight ↔ comment-card focus sync.
+ *
+ * Both the `<HighlightMark>` overlay and the `<CommentCard>` subscribe to
+ * the same focused-highlight id. Either side can call `setFocused()` to
+ * surface a highlight in both places (mark thickens border, card scrolls
+ * into view + flashes).
+ */
+
+import { useEffect, useState } from 'react'
+
+type Listener = (id: string | null) => void
+
+let focusedId: string | null = null
+const listeners = new Set<Listener>()
+
+export function setFocused(id: string | null): void {
+  if (focusedId === id) return
+  focusedId = id
+  listeners.forEach((l) => l(id))
+}
+
+export function getFocused(): string | null {
+  return focusedId
+}
+
+export function useFocusedHighlight(): string | null {
+  const [id, setId] = useState<string | null>(focusedId)
+  useEffect(() => {
+    listeners.add(setId)
+    return () => {
+      listeners.delete(setId)
+    }
+  }, [])
+  return id
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,8 @@
         "remark-html": "^16.0.1",
         "remark-math": "^6.0.0",
         "tailwind-merge": "^2.5.2",
-        "tailwindcss-animate": "^1.0.7"
+        "tailwindcss-animate": "^1.0.7",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@shadcn/ui": "^0.0.4",
@@ -2706,6 +2707,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@shadcn/ui/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://jfrog.booking.com:443/artifactory/api/npm/npm/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -12972,9 +12982,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.23.8",
-      "dev": true,
-      "license": "MIT",
+      "version": "4.4.3",
+      "resolved": "https://jfrog.booking.com:443/artifactory/api/npm/npm/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2711,7 +2711,7 @@
     },
     "node_modules/@shadcn/ui/node_modules/zod": {
       "version": "3.25.76",
-      "resolved": "https://jfrog.booking.com:443/artifactory/api/npm/npm/zod/-/zod-3.25.76.tgz",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "funding": {
@@ -12983,7 +12983,7 @@
     },
     "node_modules/zod": {
       "version": "4.4.3",
-      "resolved": "https://jfrog.booking.com:443/artifactory/api/npm/npm/zod/-/zod-4.4.3.tgz",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "remark-html": "^16.0.1",
     "remark-math": "^6.0.0",
     "tailwind-merge": "^2.5.2",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@shadcn/ui": "^0.0.4",


### PR DESCRIPTION
## Summary

Google Docs–style inline comments on `/blog/[id]` pages. Select text → right-margin "+" appears → comment in a right-rail card. Threading, reactions, owner-moderation. Anonymous, mirroring the existing likes pattern.

- **Anchoring**: simplified W3C Web Annotation — TextPosition (offset fast-path) + TextQuote (prefix/suffix, resilient to post edits) + last-resort exact match → orphan if all three fail.
- **Storage**: one JSON file per post at `data/highlights/<slug>.json` via Octokit, with SHA-based optimistic concurrency + 30s in-memory read cache.
- **6 REST routes** under `/api/blog/[id]/highlights/...` — list, create, reply, react, resolve (owner), delete (owner, both highlight and per-comment).
- **Right rail**: constraint-solved card positioning so cards never overlap; recomputes on resize / font-load. Mobile (`< lg`) falls back to a bottom-sheet composer + stacked list.
- **Anonymous identity** reuses `lib/likeUtils.ts` (hashed IP + UA + country + platform).
- **Unicode-safe postIds**: CJK + full-width punctuation work (e.g. `我做了一款旅行记录应用：mile`). Denylist-based validator blocks path traversal (`/`, `\`, `..`, null bytes, leading dots, > 200 chars) without restricting the character set.
- **Rate limit**: 5 comments / 30 reactions per 10 min per fingerprint, honeypot field on every composer, 2000-char body cap.
- **Owner moderation**: `Resolve` / `Reopen` / `Delete` (highlight or single reply) gated on `session.user.username === GITHUB_USERNAME`.

## Required deploy step (gating prod)

Add **`HIGHLIGHTS_GH_TOKEN`** to Vercel env — a fine-grained PAT (or GitHub App installation token) with `contents:write` scoped to this repo only. Without it, anonymous comment creation throws a clear error in prod (vs. the silent no-op the existing likes feature has — see `lib/smartClient.ts:197`).

Owner-moderation routes use the NextAuth session token instead, so resolve/delete keep working as the logged-in owner regardless of the service token.

## Commits

| SHA | Subject |
|---|---|
| `ab94f40` | feat(highlights): add Google Docs-style inline comments on blog posts |
| `5c16880` | fix(highlights): allow CJK + Unicode characters in postIds |

## Implementation map

```
lib/highlights/
  anchoring.ts        Range ↔ HighlightAnchor (TextPosition + TextQuote)
  schema.ts           Zod schemas + inferred types
  highlightsRepo.ts   LocalFs (dev) + GitHub (prod) storage with retry/cache
  rateLimit.ts        Sliding-window per-fingerprint limiter
  server.ts           Shared route helpers (identity, owner, ApiResponse)
  clientApi.ts        Fetch wrappers
  cardLayout.ts       Constraint solver (pure)
  syncFocus.ts        Pub-sub for highlight ↔ card focus

components/Highlights/
  HighlightLayer.tsx  Orchestrator — wraps BlogPostContent
  SelectionToolbar.tsx  Floating "+" in the right gutter
  CommentComposer.tsx   Body + name + honeypot
  HighlightMark.tsx     Absolute-positioned overlay rects on the article
  CommentRail.tsx       Constraint-solved cards aside the article
  CommentCard.tsx       Single thread + reply form + reactions + owner ctl
  Reactions.tsx         Quick-pick emoji bar

app/api/blog/[id]/highlights/
  route.ts                                   GET, POST
  [hid]/route.ts                             DELETE (owner)
  [hid]/replies/route.ts                     POST
  [hid]/resolve/route.ts                     POST (owner)
  [hid]/comments/[cid]/route.ts              DELETE (owner)
  [hid]/comments/[cid]/reactions/route.ts    POST
```

## Verification

- [x] `npx jest` — **142/142** pass (42 new across anchoring 15, repo 18, rate limit 6, card layout 6 + 1 schema implicit)
- [x] `npx tsc --noEmit` — clean
- [x] `npx next lint` — clean
- [x] `npm run build` — succeeds; new routes register correctly
- [x] **End-to-end smoke test via headless browser** — both an English slug (`a-complex-web-app-refactor`) and a CJK slug (`我做了一款旅行记录应用：mile`):
  - selection fires `selectionchange` → toolbar renders in the right gutter at the selection's top
  - click → composer opens with "Commenting on '...'" preview
  - submit → 200 OK, card appears in the rail at **pixel-perfect alignment with the highlight overlay** (constraint solver: 0px diff between mark.top and card.top)
  - reload → highlight + card restored from `data/highlights/<slug>.json`
  - reaction → toggles, persists fingerprint to JSON
  - reply → thread grows on disk and in UI
  - **zero console errors** throughout the session

## Test plan

- [ ] **Smoke (dev)**: `npm run dev` → open any post → select text → toolbar appears in the right gutter
- [ ] **CJK post** (e.g. `我做了一款旅行记录应用：mile`) — verify comment flow works (this was the bug in `5c16880`)
- [ ] **Submit a comment** → card appears in the rail, persisted to `data/highlights/<slug>.json` locally
- [ ] **Reload** → highlight + card restored from disk
- [ ] **Edit the post body** to shift offsets by a few chars → reload → highlight still resolves via prefix/suffix
- [ ] **Reply** → reply appears nested under the root in the same card
- [ ] **React** → emoji count increments, click again to un-react
- [ ] **Owner login + Resolve** → card dims, button toggles to Reopen
- [ ] **Owner Delete on a reply** → reply disappears; thread structure preserved
- [ ] **Owner Delete on a root comment** → entire highlight + thread removed
- [ ] **Spam test**: send 6 comments in 60s → 6th rejected with 429
- [ ] **Mobile (< 1024px viewport)**: composer opens as a bottom sheet; existing highlights show as a stacked list under the article
- [ ] **Multiple highlights stacked closely**: cards never overlap (constraint solver)
- [ ] **Heavy edit so prefix+suffix don't match**: highlight either falls back to first exact-match or filters out (no crash)

## Notes for review

- Did **not** modify `BlogPostContent.tsx` — `HighlightLayer` wraps it, marks render as overlays. Reverting the feature is one-import change in `app/blog/[id]/component.tsx`.
- The `highlightsRepo` interface is the seam if we ever migrate off GitHub-as-DB to Postgres/Neon.
- `rehype-sanitize` deferred — comment bodies render as plain text (`whitespace-pre-wrap`), no HTML interpretation, no XSS surface.
- Cloudflare Turnstile env hook is documented but unwired; ready to enable when needed.