### PR TITLE
fix(highlights): live-feedback fixes — composer position, theme colors, mobile width, error surfacing

### DIFF
--- a/app/api/blog/[id]/highlights/[hid]/comments/[cid]/reactions/route.ts
+++ b/app/api/blog/[id]/highlights/[hid]/comments/[cid]/reactions/route.ts
@@ -6,6 +6,7 @@ import { checkReactionRateLimit } from '@/lib/highlights/rateLimit'
 import {
   ApiBodyError,
   apiError,
+  apiErrorFrom,
   apiOk,
   extractIdentity,
   parseBody,
@@ -75,7 +76,6 @@ export async function POST(
     return apiOk({ reactions })
   } catch (err) {
     if (err instanceof ApiBodyError) return apiError(err.message, 400)
-    console.error('POST /reactions failed', err)
-    return apiError('Failed to toggle reaction', 500)
+    return apiErrorFrom(err, 'Failed to toggle reaction')
   }
 }

--- a/app/api/blog/[id]/highlights/[hid]/comments/[cid]/route.ts
+++ b/app/api/blog/[id]/highlights/[hid]/comments/[cid]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from 'next/server'
 
 import { getHighlightsRepo } from '@/lib/highlights/highlightsRepo'
-import { apiError, apiOk, getOwnerToken, isOwner } from '@/lib/highlights/server'
+import { apiError, apiErrorFrom, apiOk, getOwnerToken, isOwner } from '@/lib/highlights/server'
 
 export async function DELETE(
   _req: NextRequest,
@@ -47,7 +47,6 @@ export async function DELETE(
     )
     return apiOk({ ok: true, removedHighlight: isRoot })
   } catch (err) {
-    console.error('DELETE /comments/[cid] failed', err)
-    return apiError('Failed to delete comment', 500)
+    return apiErrorFrom(err, 'Failed to delete comment')
   }
 }

--- a/app/api/blog/[id]/highlights/[hid]/replies/route.ts
+++ b/app/api/blog/[id]/highlights/[hid]/replies/route.ts
@@ -7,6 +7,7 @@ import { checkCommentRateLimit } from '@/lib/highlights/rateLimit'
 import {
   ApiBodyError,
   apiError,
+  apiErrorFrom,
   apiOk,
   extractIdentity,
   parseBody,
@@ -75,7 +76,6 @@ export async function POST(
     return apiOk({ comment: reply })
   } catch (err) {
     if (err instanceof ApiBodyError) return apiError(err.message, 400)
-    console.error('POST /highlights/[hid]/replies failed', err)
-    return apiError('Failed to add reply', 500)
+    return apiErrorFrom(err, 'Failed to add reply')
   }
 }

--- a/app/api/blog/[id]/highlights/[hid]/resolve/route.ts
+++ b/app/api/blog/[id]/highlights/[hid]/resolve/route.ts
@@ -5,6 +5,7 @@ import { getHighlightsRepo } from '@/lib/highlights/highlightsRepo'
 import {
   ApiBodyError,
   apiError,
+  apiErrorFrom,
   apiOk,
   getOwnerToken,
   isOwner,
@@ -51,7 +52,6 @@ export async function POST(
     return apiOk({ highlight: next })
   } catch (err) {
     if (err instanceof ApiBodyError) return apiError(err.message, 400)
-    console.error('POST /resolve failed', err)
-    return apiError('Failed to update highlight', 500)
+    return apiErrorFrom(err, 'Failed to update highlight')
   }
 }

--- a/app/api/blog/[id]/highlights/[hid]/route.ts
+++ b/app/api/blog/[id]/highlights/[hid]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from 'next/server'
 
 import { getHighlightsRepo } from '@/lib/highlights/highlightsRepo'
-import { apiError, apiOk, getOwnerToken, isOwner } from '@/lib/highlights/server'
+import { apiError, apiErrorFrom, apiOk, getOwnerToken, isOwner } from '@/lib/highlights/server'
 
 export async function DELETE(
   _req: NextRequest,
@@ -26,7 +26,6 @@ export async function DELETE(
     await repo.save(params.id, updated, sha, `Delete highlight ${params.hid}`)
     return apiOk({ ok: true })
   } catch (err) {
-    console.error('DELETE /highlights/[hid] failed', err)
-    return apiError('Failed to delete highlight', 500)
+    return apiErrorFrom(err, 'Failed to delete highlight')
   }
 }

--- a/app/api/blog/[id]/highlights/route.ts
+++ b/app/api/blog/[id]/highlights/route.ts
@@ -7,6 +7,7 @@ import { checkCommentRateLimit } from '@/lib/highlights/rateLimit'
 import {
   ApiBodyError,
   apiError,
+  apiErrorFrom,
   apiOk,
   extractIdentity,
   isOwner,
@@ -41,8 +42,7 @@ export async function GET(
       isOwner: owner,
     })
   } catch (err) {
-    console.error('GET /highlights failed', err)
-    return apiError('Failed to load highlights', 500)
+    return apiErrorFrom(err, 'Failed to load highlights')
   }
 }
 
@@ -100,7 +100,6 @@ export async function POST(
     return apiOk({ highlight: newHighlight })
   } catch (err) {
     if (err instanceof ApiBodyError) return apiError(err.message, 400)
-    console.error('POST /highlights failed', err)
-    return apiError('Failed to create highlight', 500)
+    return apiErrorFrom(err, 'Failed to create highlight')
   }
 }

--- a/components/Highlights/CommentCard.tsx
+++ b/components/Highlights/CommentCard.tsx
@@ -44,8 +44,8 @@ export function CommentCard(props: CommentCardProps) {
       onMouseEnter={() => setFocused(highlight.id)}
       onMouseLeave={() => setFocused(null)}
       className={[
-        'rounded-lg border bg-white p-3 shadow-sm transition-all',
-        focused ? 'border-amber-400 shadow-md' : 'border-gray-200',
+        'rounded-lg border bg-card p-3 shadow-sm transition-all',
+        focused ? 'border-primary/60 shadow-md' : 'border-border',
         highlight.resolved ? 'opacity-60' : '',
       ].join(' ')}
     >
@@ -55,7 +55,7 @@ export function CommentCard(props: CommentCardProps) {
       />
 
       {replies.length > 0 && (
-        <div className='mt-2 space-y-2 border-l-2 border-gray-100 pl-2'>
+        <div className='mt-2 space-y-2 border-l-2 border-border pl-2'>
           {replies.map((reply) => (
             <CommentBody
               key={reply.id}
@@ -75,7 +75,7 @@ export function CommentCard(props: CommentCardProps) {
           <button
             type='button'
             onClick={() => setReplyOpen(true)}
-            className='text-xs font-medium text-amber-600 hover:text-amber-700'
+            className='text-xs font-medium text-primary hover:underline'
           >
             Reply
           </button>
@@ -85,7 +85,7 @@ export function CommentCard(props: CommentCardProps) {
             <button
               type='button'
               onClick={() => onResolve(highlight.id, !highlight.resolved)}
-              className='inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs text-gray-500 hover:bg-gray-100'
+              className='inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs text-muted-foreground hover:bg-muted'
               aria-label={highlight.resolved ? 'Reopen' : 'Resolve'}
             >
               {highlight.resolved ? <RotateCcw className='h-3 w-3' /> : <CheckCircle className='h-3 w-3' />}
@@ -94,7 +94,7 @@ export function CommentCard(props: CommentCardProps) {
             <button
               type='button'
               onClick={() => onDelete(highlight.id)}
-              className='inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs text-red-500 hover:bg-red-50'
+              className='inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs text-destructive hover:bg-destructive/10'
               aria-label='Delete highlight'
             >
               <Trash2 className='h-3 w-3' />
@@ -136,7 +136,7 @@ function CommentBody({
   compact?: boolean
 }) {
   if (comment.hidden) {
-    return <div className='text-xs italic text-gray-400'>(removed)</div>
+    return <div className='text-xs italic text-muted-foreground'>(removed)</div>
   }
 
   const displayName = comment.authorName?.trim() || `Anonymous ${comment.fingerprint.slice(0, 4)}`
@@ -146,21 +146,21 @@ function CommentBody({
     <div className={compact ? 'text-xs' : 'text-sm'}>
       <div className='flex items-center justify-between gap-2'>
         <div className='flex items-center gap-1.5'>
-          <span className='font-medium text-gray-900'>{displayName}</span>
-          <span className='text-[11px] text-gray-400'>· {time}</span>
+          <span className='font-medium text-foreground'>{displayName}</span>
+          <span className='text-[11px] text-muted-foreground'>· {time}</span>
         </div>
         {isOwner && compact && (
           <button
             type='button'
             onClick={onDelete}
-            className='text-[11px] text-red-500 hover:underline'
+            className='text-[11px] text-destructive hover:underline'
             aria-label='Delete reply'
           >
             <Trash2 className='h-3 w-3' />
           </button>
         )}
       </div>
-      <div className={['mt-1 whitespace-pre-wrap text-gray-700', compact ? '' : ''].join(' ')}>
+      <div className='mt-1 whitespace-pre-wrap text-foreground/80'>
         {comment.body}
       </div>
       <div className='mt-1.5'>

--- a/components/Highlights/CommentComposer.tsx
+++ b/components/Highlights/CommentComposer.tsx
@@ -54,7 +54,7 @@ export function CommentComposer({
   }
 
   return (
-    <div className='flex flex-col gap-2 rounded-lg border border-gray-200 bg-white p-3'>
+    <div className='flex flex-col gap-2 rounded-lg border border-border bg-card p-3'>
       <textarea
         value={body}
         onChange={(e) => setBody(e.target.value)}
@@ -62,7 +62,7 @@ export function CommentComposer({
         rows={3}
         maxLength={2000}
         disabled={submitting || disabled}
-        className='w-full resize-none rounded border border-gray-200 bg-white px-2 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:border-amber-400 focus:outline-none'
+        className='w-full resize-none rounded border border-border bg-background px-2 py-1.5 text-sm text-foreground placeholder-muted-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary/40'
         onKeyDown={(e) => {
           if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
             e.preventDefault()
@@ -77,7 +77,7 @@ export function CommentComposer({
         placeholder='Your name (optional)'
         maxLength={40}
         disabled={submitting || disabled}
-        className='w-full rounded border border-gray-200 bg-white px-2 py-1 text-xs text-gray-700 placeholder-gray-400 focus:border-amber-400 focus:outline-none'
+        className='w-full rounded border border-border bg-background px-2 py-1 text-xs text-foreground placeholder-muted-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary/40'
       />
       {/* Honeypot — visually hidden, never tabbable. */}
       <input
@@ -89,14 +89,14 @@ export function CommentComposer({
         aria-hidden='true'
         className='absolute -left-[9999px] -top-[9999px] h-0 w-0 opacity-0'
       />
-      {error && <div className='text-xs text-red-600'>{error}</div>}
+      {error && <div className='text-xs text-destructive'>{error}</div>}
       <div className='flex items-center justify-end gap-2'>
         {onCancel && (
           <button
             type='button'
             onClick={onCancel}
             disabled={submitting}
-            className='inline-flex h-7 items-center gap-1 rounded px-2 text-xs text-gray-600 hover:bg-gray-100'
+            className='inline-flex h-7 items-center gap-1 rounded px-2 text-xs text-muted-foreground hover:bg-muted'
           >
             <X className='h-3 w-3' />
             Cancel
@@ -106,7 +106,7 @@ export function CommentComposer({
           type='button'
           onClick={handleSubmit}
           disabled={submitting || disabled || !body.trim()}
-          className='inline-flex h-7 items-center gap-1 rounded bg-amber-400 px-3 text-xs font-medium text-white shadow-sm hover:bg-amber-500 disabled:cursor-not-allowed disabled:opacity-50'
+          className='inline-flex h-7 items-center gap-1 rounded bg-primary px-3 text-xs font-medium text-primary-foreground shadow-sm hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50'
         >
           <Send className='h-3 w-3' />
           {submitting ? 'Sending…' : submitLabel}

--- a/components/Highlights/HighlightLayer.tsx
+++ b/components/Highlights/HighlightLayer.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 
-import { rangeToAnchor } from '@/lib/highlights/anchoring'
+import { anchorToRange, rangeToAnchor } from '@/lib/highlights/anchoring'
 import {
   createHighlight,
   createReply,
@@ -31,8 +31,9 @@ interface HighlightLayerProps {
  * Wraps the post's article content with:
  *   - selection capture + floating "+" toolbar
  *   - overlay highlight marks
- *   - right-rail of Google Docs-style comment cards
- *   - composer for new highlights and replies
+ *   - right-rail of Google Docs-style comment cards (lg+)
+ *   - composer for new highlights, vertically aligned to the selection
+ *   - bottom-sheet composer + stacked cards on narrow viewports
  *
  * Does not modify `BlogPostContent` — the article DOM stays untouched and
  * we render anchored marks/cards on top.
@@ -43,6 +44,7 @@ export function HighlightLayer({ postId, children }: HighlightLayerProps) {
   const [fingerprint, setFingerprint] = useState<string | null>(null)
   const [isOwner, setIsOwner] = useState(false)
   const [pending, setPending] = useState<HighlightAnchor | null>(null)
+  const [pendingTop, setPendingTop] = useState<number | null>(null)
   const [recomputeKey, setRecomputeKey] = useState(0)
   const [error, setError] = useState<string | null>(null)
 
@@ -75,9 +77,31 @@ export function HighlightLayer({ postId, children }: HighlightLayerProps) {
     if (typeof document !== 'undefined' && document.fonts) {
       document.fonts.ready.then(() => setRecomputeKey((k) => k + 1)).catch(() => {})
     }
-    window.addEventListener('resize', () => setRecomputeKey((k) => k + 1))
-    return () => ro.disconnect()
+    const onResize = () => setRecomputeKey((k) => k + 1)
+    window.addEventListener('resize', onResize)
+    return () => {
+      ro.disconnect()
+      window.removeEventListener('resize', onResize)
+    }
   }, [])
+
+  // Recompute pending composer top from the pending anchor
+  useEffect(() => {
+    if (!pending) {
+      setPendingTop(null)
+      return
+    }
+    const article = articleRef.current
+    if (!article) return
+    const range = anchorToRange(pending, article)
+    if (!range) {
+      setPendingTop(0)
+      return
+    }
+    const articleRect = article.getBoundingClientRect()
+    const rangeRect = range.getBoundingClientRect()
+    setPendingTop(rangeRect.top - articleRect.top)
+  }, [pending, recomputeKey])
 
   // Handlers — keep optimistic UI: append/update local state, server is source on next reload
   const handleAddComment = useCallback(() => {
@@ -171,6 +195,9 @@ export function HighlightLayer({ postId, children }: HighlightLayerProps) {
   )
 
   const article = articleRef.current
+  const pendingPreview = pending
+    ? pending.exact.slice(0, 40) + (pending.exact.length > 40 ? '…' : '')
+    : ''
 
   return (
     <div className='relative mx-auto w-full max-w-7xl'>
@@ -191,25 +218,33 @@ export function HighlightLayer({ postId, children }: HighlightLayerProps) {
         />
       </div>
 
-      {/* Composer — appears in the rail when a new highlight is being drafted. */}
-      <aside className='pointer-events-none absolute right-0 top-0 hidden w-72 lg:block'>
-        <div className='pointer-events-auto sticky top-4 max-h-[calc(100vh-2rem)] overflow-y-auto pl-4'>
-          {pending && (
-            <div className='mb-3 rounded-lg border-2 border-amber-300 bg-amber-50/40 p-2'>
-              <div className='mb-2 text-xs text-amber-900'>
-                Commenting on “{pending.exact.slice(0, 40)}{pending.exact.length > 40 ? '…' : ''}”
+      {/* Right-rail (lg+): composer at the selection's vertical top, plus existing cards. */}
+      <aside className='absolute right-0 top-0 hidden w-72 lg:block'>
+        <div className='relative pl-4'>
+          {pending && pendingTop !== null && (
+            <div
+              className='absolute left-4 right-0'
+              style={{ top: pendingTop }}
+            >
+              <div className='rounded-lg border border-primary/40 bg-card p-2 shadow-sm'>
+                <div className='mb-2 text-xs text-muted-foreground'>
+                  Commenting on “{pendingPreview}”
+                </div>
+                <CommentComposer
+                  placeholder='Add a comment…'
+                  submitLabel='Comment'
+                  onSubmit={handleSubmitNew}
+                  onCancel={() => {
+                    setPending(null)
+                    setError(null)
+                  }}
+                />
+                {error && (
+                  <div className='mt-2 rounded border border-destructive/30 bg-destructive/10 p-2 text-xs text-destructive'>
+                    {error}
+                  </div>
+                )}
               </div>
-              <CommentComposer
-                placeholder='Add a comment…'
-                submitLabel='Comment'
-                onSubmit={handleSubmitNew}
-                onCancel={() => setPending(null)}
-              />
-            </div>
-          )}
-          {error && (
-            <div className='mb-2 rounded border border-red-200 bg-red-50 p-2 text-xs text-red-700'>
-              {error}
             </div>
           )}
           <CommentRail
@@ -226,20 +261,27 @@ export function HighlightLayer({ postId, children }: HighlightLayerProps) {
         </div>
       </aside>
 
-      {/* Mobile fallback: bottom sheet for any active composer or thread.
-          Phase 8 will flesh out — for v1 we tap into the same components. */}
+      {/* Mobile (< lg): composer as a centered bottom sheet matching post body width. */}
       {pending && (
-        <div className='fixed inset-x-0 bottom-0 z-50 border-t border-amber-200 bg-white p-3 shadow-lg lg:hidden'>
-          <div className='mx-auto max-w-3xl'>
-            <div className='mb-2 text-xs text-amber-900'>
-              Commenting on “{pending.exact.slice(0, 40)}{pending.exact.length > 40 ? '…' : ''}”
+        <div className='fixed inset-x-0 bottom-0 z-50 px-4 pb-4 pt-2 lg:hidden'>
+          <div className='mx-auto max-w-3xl rounded-lg border border-border bg-card p-3 shadow-lg'>
+            <div className='mb-2 text-xs text-muted-foreground'>
+              Commenting on “{pendingPreview}”
             </div>
             <CommentComposer
               placeholder='Add a comment…'
               submitLabel='Comment'
               onSubmit={handleSubmitNew}
-              onCancel={() => setPending(null)}
+              onCancel={() => {
+                setPending(null)
+                setError(null)
+              }}
             />
+            {error && (
+              <div className='mt-2 rounded border border-destructive/30 bg-destructive/10 p-2 text-xs text-destructive'>
+                {error}
+              </div>
+            )}
           </div>
         </div>
       )}
@@ -247,7 +289,7 @@ export function HighlightLayer({ postId, children }: HighlightLayerProps) {
       {/* Mobile: existing highlights as a stacked list under the article. */}
       {highlights.length > 0 && (
         <div className='mt-6 space-y-3 px-4 lg:hidden'>
-          <h2 className='text-sm font-semibold text-gray-700'>Inline comments</h2>
+          <h2 className='text-sm font-semibold text-muted-foreground'>Inline comments</h2>
           {highlights.map((h) => (
             <CommentCard
               key={h.id}

--- a/components/Highlights/HighlightMark.tsx
+++ b/components/Highlights/HighlightMark.tsx
@@ -67,11 +67,13 @@ export function HighlightMark({ highlight, articleEl, recomputeKey = 0 }: Highli
           style={{ top: r.top, left: r.left, width: r.width, height: r.height }}
           className={[
             'absolute z-10 cursor-pointer rounded-sm border-b-2 transition-colors',
+            // Highlights stay yellow — that's the canonical highlighter convention,
+            // and the rest of the chrome (rail, buttons) is theme-tinted instead.
             isResolved
-              ? 'bg-gray-200/30 border-gray-300/60 hover:bg-gray-200/50'
-              : 'bg-amber-200/40 border-amber-300/70 hover:bg-amber-200/70',
-            isFocused && !isResolved ? 'bg-amber-300/60 border-amber-500' : '',
-            isFocused && isResolved ? 'bg-gray-300/60 border-gray-500' : '',
+              ? 'border-muted-foreground/40 bg-muted/40 hover:bg-muted/60'
+              : 'border-yellow-400/60 bg-yellow-200/40 hover:bg-yellow-200/70',
+            isFocused && !isResolved ? 'border-yellow-500 bg-yellow-300/60' : '',
+            isFocused && isResolved ? 'border-muted-foreground bg-muted/70' : '',
           ].join(' ')}
         />
       ))}

--- a/components/Highlights/Reactions.tsx
+++ b/components/Highlights/Reactions.tsx
@@ -27,8 +27,8 @@ export function Reactions({ reactions, fingerprint, onToggle, disabled }: Reacti
             className={[
               'inline-flex h-6 items-center gap-1 rounded-full border px-1.5 text-[11px] transition-colors',
               reacted
-                ? 'border-amber-300 bg-amber-50 text-amber-900'
-                : 'border-gray-200 bg-white text-gray-600 hover:bg-gray-50',
+                ? 'border-primary/40 bg-primary/10 text-primary'
+                : 'border-border bg-card text-muted-foreground hover:bg-muted',
               disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer',
             ].join(' ')}
             aria-pressed={reacted}

--- a/components/Highlights/SelectionToolbar.tsx
+++ b/components/Highlights/SelectionToolbar.tsx
@@ -80,7 +80,7 @@ export function SelectionToolbar({ containerRef, onAddComment, suppressed }: Sel
       }}
       onClick={onAddComment}
       style={{ top: pos.top, left: pos.left }}
-      className='absolute z-30 flex h-8 w-8 items-center justify-center rounded-full bg-amber-400 text-white shadow-md transition-all hover:scale-110 hover:bg-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-300'
+      className='absolute z-30 flex h-8 w-8 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-md transition-all hover:scale-110 hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-ring'
       aria-label='Add comment on selection'
     >
       <MessageSquarePlus className='h-4 w-4' />

--- a/lib/highlights/server.ts
+++ b/lib/highlights/server.ts
@@ -35,6 +35,24 @@ export function apiError(message: string, status = 400): NextResponse<ApiRespons
   return NextResponse.json<ApiResponse<never>>({ success: false, error: message }, { status })
 }
 
+/**
+ * Convert an unknown error from a route catch block into an `ApiResponse`.
+ * The actual error message is surfaced to the client — this is a personal
+ * blog where debuggability beats security-via-obscurity, and the only
+ * sensitive thing we care about (the GitHub token) never appears in error
+ * messages anyway. Always logs the full stack server-side.
+ */
+export function apiErrorFrom(
+  err: unknown,
+  fallback = 'Internal server error',
+  status = 500,
+): NextResponse<ApiResponse<never>> {
+  console.error('[highlights]', err)
+  const message =
+    err instanceof Error && err.message ? err.message : fallback
+  return apiError(message, status)
+}
+
 export interface RequestIdentity {
   fingerprint: string
   country: string


### PR DESCRIPTION
## Summary

Four feedback items from live testing of #81 after merge:

### 1. POST /highlights returned 500 with no usable error
The route's catch-all returned generic `"Failed to create highlight"` for every error. Vercel's network panel shows 500 but the response body says nothing actionable.

**Fix**: Added `apiErrorFrom(err, fallback)` in `lib/highlights/server.ts` that surfaces the actual error message in the response and logs the stack server-side. All 6 routes updated. The most likely root cause for the live 500 is `HIGHLIGHTS_GH_TOKEN` not being set on Vercel — once this PR ships, the response body will say so explicitly.

This is a deliberate trade-off: showing internal errors in 500 responses is normally questionable, but on a personal blog with simple errors the debuggability is worth more than the obscurity, and the only sensitive thing we care about (the GitHub token) never appears in error messages anyway.

### 2. Composer was anchored to the rail's top, not the selection
Selecting text mid-page meant scrolling the rail to find the composer. Awkward.

**Fix**: Compute `pendingTop` from the selection's anchor (same logic the rail uses to position cards) and render the composer absolutely at that vertical offset within the rail. Composer now visually anchors to the selected text just like a card. Same UX as Google Docs.

### 3. Mobile composer stretched edge-to-edge
The bottom-sheet wrapper used `inset-x-0` (full viewport width).

**Fix**: Constrain the visible card to `max-w-3xl` matching the post body, with horizontal padding on the wrapper. The bottom sheet now reads as a floating card aligned with the article column.

### 4. Color scheme clashed with the site
The feature used a saturated amber palette (#FBC400). The site is built around `--primary: #2357cd` (blue), `--muted` grays, `--border` light gray. Components looked grafted on.

**Fix**: Switched every chrome surface to the site's CSS-variable theme tokens — `border-border`, `bg-card`, `text-foreground`, `text-muted-foreground`, `bg-primary`, `bg-destructive`, etc. Selection toolbar, composer chrome, comment cards, reaction pills, owner action buttons all now use the site's tokens.

The highlight overlay itself stays yellow because that's the canonical highlighter convention (Google Docs, Medium, Notion all use yellow for inline comment anchors). Everything else is theme-tinted.

Side benefit: components now adapt to the dark-mode CSS variables the site already defines, even though dark mode isn't currently turned on.

## Required deploy step (still gating prod)

`HIGHLIGHTS_GH_TOKEN` must be set on Vercel before anonymous comment writes work in production. Fine-grained PAT (or GitHub App installation token) with `contents:write` scoped to the Cofe repo only. Without it, the new error surfacing will tell users (and the logs) exactly what's missing.

## Files changed

13 files, +130 / -71 lines:

- `lib/highlights/server.ts` — new `apiErrorFrom()` helper
- `app/api/blog/[id]/highlights/**` — 6 routes use the new helper
- `components/Highlights/HighlightLayer.tsx` — composer position + mobile width + theme colors
- `components/Highlights/{CommentCard,CommentComposer,HighlightMark,Reactions,SelectionToolbar}.tsx` — theme tokens

## Test plan

- [ ] **Live verification of error surfacing**: post a comment in prod after merge — if `HIGHLIGHTS_GH_TOKEN` is missing, the response now says so explicitly. Set the token on Vercel, retry, comment goes through.
- [ ] **Composer position**: select text in the middle of a long post, click "+", composer renders next to the selection (not at the top of the rail).
- [ ] **Mobile (< 1024px)**: shrink window, select text — bottom-sheet composer is centered with `max-w-3xl` width matching the post body.
- [ ] **Color scheme**: visually compare composer + buttons + cards against the rest of the site. Should feel native.
- [ ] **Highlight overlay**: still yellow on the selected text (intentional — keeps the highlighter convention).

## Notes

Local install couldn't complete due to network instability during this session, so CI is the verification. Last green run was #81; my changes are minimal additions on top.