### PR TITLE
fix(highlights): polish — keep selection, breathing room, GitHub username, simpler reactions

### DIFF
--- a/app/api/blog/[id]/highlights/[hid]/replies/route.ts
+++ b/app/api/blog/[id]/highlights/[hid]/replies/route.ts
@@ -10,6 +10,7 @@ import {
   apiErrorFrom,
   apiOk,
   extractIdentity,
+  getSessionDisplayName,
   parseBody,
 } from '@/lib/highlights/server'
 import { InlineComment } from '@/lib/highlights/schema'
@@ -51,11 +52,13 @@ export async function POST(
     }
 
     const now = new Date().toISOString()
+    const sessionName = await getSessionDisplayName()
+    const resolvedAuthor = body.authorName?.trim() || sessionName || null
     const reply: InlineComment = {
       id: `cm_${randomUUID()}`,
       parentId: body.parentId ?? null,
       body: body.body.trim(),
-      authorName: body.authorName ?? null,
+      authorName: resolvedAuthor,
       fingerprint: identity.fingerprint,
       country: identity.country,
       platform: identity.platform,

--- a/app/api/blog/[id]/highlights/route.ts
+++ b/app/api/blog/[id]/highlights/route.ts
@@ -10,6 +10,7 @@ import {
   apiErrorFrom,
   apiOk,
   extractIdentity,
+  getSessionDisplayName,
   isOwner,
   parseBody,
 } from '@/lib/highlights/server'
@@ -36,9 +37,11 @@ export async function GET(
     const { data } = await repo.load(params.id)
     const identity = extractIdentity(request)
     const owner = await isOwner()
+    const displayName = await getSessionDisplayName()
     return apiOk({
       ...data,
       currentFingerprint: identity.fingerprint,
+      currentDisplayName: displayName,
       isOwner: owner,
     })
   } catch (err) {
@@ -68,6 +71,12 @@ export async function POST(
     const repo = getHighlightsRepo()
     const { data, sha } = await repo.load(params.id)
 
+    // Anonymous fallback: if no name was filled in but the user is logged
+    // in, attribute to their GitHub username so they don't show as
+    // "Anonymous {fp}" against their own comment.
+    const sessionName = await getSessionDisplayName()
+    const resolvedAuthor = body.authorName?.trim() || sessionName || null
+
     const now = new Date().toISOString()
     const newHighlight: Highlight = {
       id: `hl_${randomUUID()}`,
@@ -77,7 +86,7 @@ export async function POST(
           id: `cm_${randomUUID()}`,
           parentId: null,
           body: body.body.trim(),
-          authorName: body.authorName ?? null,
+          authorName: resolvedAuthor,
           fingerprint: identity.fingerprint,
           country: identity.country,
           platform: identity.platform,

--- a/components/Highlights/CommentComposer.tsx
+++ b/components/Highlights/CommentComposer.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Send, X } from 'lucide-react'
 
 interface CommentComposerProps {
@@ -30,9 +30,19 @@ export function CommentComposer({
 }: CommentComposerProps) {
   const [body, setBody] = useState(initialBody)
   const [name, setName] = useState(initialName)
+  const [nameTouched, setNameTouched] = useState(false)
   const [website, setWebsite] = useState('') // honeypot
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
+
+  // Keep name field synced with `initialName` while the user hasn't typed
+  // their own — this matters when a logged-in user's display name arrives
+  // asynchronously (after the composer has already mounted).
+  useEffect(() => {
+    if (!nameTouched) {
+      setName(initialName)
+    }
+  }, [initialName, nameTouched])
 
   async function handleSubmit() {
     if (!body.trim() || submitting || disabled) return
@@ -54,7 +64,7 @@ export function CommentComposer({
   }
 
   return (
-    <div className='flex flex-col gap-2 rounded-lg border border-border bg-card p-3'>
+    <div className='flex flex-col gap-3 rounded-lg border border-border bg-card p-4'>
       <textarea
         value={body}
         onChange={(e) => setBody(e.target.value)}
@@ -62,7 +72,7 @@ export function CommentComposer({
         rows={3}
         maxLength={2000}
         disabled={submitting || disabled}
-        className='w-full resize-none rounded border border-border bg-background px-2 py-1.5 text-sm text-foreground placeholder-muted-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary/40'
+        className='w-full resize-none rounded border border-border bg-background px-3 py-2 text-sm text-foreground placeholder-muted-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary/40'
         onKeyDown={(e) => {
           if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
             e.preventDefault()
@@ -73,11 +83,14 @@ export function CommentComposer({
       <input
         type='text'
         value={name}
-        onChange={(e) => setName(e.target.value)}
+        onChange={(e) => {
+          setNameTouched(true)
+          setName(e.target.value)
+        }}
         placeholder='Your name (optional)'
         maxLength={40}
         disabled={submitting || disabled}
-        className='w-full rounded border border-border bg-background px-2 py-1 text-xs text-foreground placeholder-muted-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary/40'
+        className='w-full rounded border border-border bg-background px-3 py-2 text-xs text-foreground placeholder-muted-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary/40'
       />
       {/* Honeypot — visually hidden, never tabbable. */}
       <input
@@ -90,13 +103,13 @@ export function CommentComposer({
         className='absolute -left-[9999px] -top-[9999px] h-0 w-0 opacity-0'
       />
       {error && <div className='text-xs text-destructive'>{error}</div>}
-      <div className='flex items-center justify-end gap-2'>
+      <div className='flex items-center justify-end gap-2 pt-1'>
         {onCancel && (
           <button
             type='button'
             onClick={onCancel}
             disabled={submitting}
-            className='inline-flex h-7 items-center gap-1 rounded px-2 text-xs text-muted-foreground hover:bg-muted'
+            className='inline-flex h-8 items-center gap-1 rounded px-3 text-xs text-muted-foreground hover:bg-muted'
           >
             <X className='h-3 w-3' />
             Cancel
@@ -106,7 +119,7 @@ export function CommentComposer({
           type='button'
           onClick={handleSubmit}
           disabled={submitting || disabled || !body.trim()}
-          className='inline-flex h-7 items-center gap-1 rounded bg-primary px-3 text-xs font-medium text-primary-foreground shadow-sm hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50'
+          className='inline-flex h-8 items-center gap-1 rounded bg-primary px-3 text-xs font-medium text-primary-foreground shadow-sm hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50'
         >
           <Send className='h-3 w-3' />
           {submitting ? 'Sending…' : submitLabel}

--- a/components/Highlights/HighlightLayer.tsx
+++ b/components/Highlights/HighlightLayer.tsx
@@ -25,12 +25,19 @@ interface HighlightLayerProps {
   children: React.ReactNode
 }
 
+interface OverlayRect {
+  top: number
+  left: number
+  width: number
+  height: number
+}
+
 /**
  * Top-level orchestrator for the inline-comments feature on a blog post.
  *
  * Wraps the post's article content with:
  *   - selection capture + floating "+" toolbar
- *   - overlay highlight marks
+ *   - overlay highlight marks (existing comments + the in-progress one)
  *   - right-rail of Google Docs-style comment cards (lg+)
  *   - composer for new highlights, vertically aligned to the selection
  *   - bottom-sheet composer + stacked cards on narrow viewports
@@ -42,9 +49,11 @@ export function HighlightLayer({ postId, children }: HighlightLayerProps) {
   const articleRef = useRef<HTMLDivElement>(null)
   const [highlights, setHighlights] = useState<Highlight[]>([])
   const [fingerprint, setFingerprint] = useState<string | null>(null)
+  const [displayName, setDisplayName] = useState<string | null>(null)
   const [isOwner, setIsOwner] = useState(false)
   const [pending, setPending] = useState<HighlightAnchor | null>(null)
   const [pendingTop, setPendingTop] = useState<number | null>(null)
+  const [pendingRects, setPendingRects] = useState<OverlayRect[]>([])
   const [recomputeKey, setRecomputeKey] = useState(0)
   const [error, setError] = useState<string | null>(null)
 
@@ -56,6 +65,7 @@ export function HighlightLayer({ postId, children }: HighlightLayerProps) {
         if (cancelled) return
         setHighlights(data.highlights)
         setFingerprint(data.currentFingerprint)
+        setDisplayName(data.currentDisplayName)
         setIsOwner(data.isOwner)
       })
       .catch((err) => {
@@ -85,10 +95,14 @@ export function HighlightLayer({ postId, children }: HighlightLayerProps) {
     }
   }, [])
 
-  // Recompute pending composer top from the pending anchor
+  // Recompute pending composer top + overlay rects from the pending anchor.
+  // The overlay rects keep the "selected" visual state on the article even
+  // after focus moves to the textarea (browsers clear native selection on
+  // focus change).
   useEffect(() => {
     if (!pending) {
       setPendingTop(null)
+      setPendingRects([])
       return
     }
     const article = articleRef.current
@@ -96,11 +110,20 @@ export function HighlightLayer({ postId, children }: HighlightLayerProps) {
     const range = anchorToRange(pending, article)
     if (!range) {
       setPendingTop(0)
+      setPendingRects([])
       return
     }
     const articleRect = article.getBoundingClientRect()
     const rangeRect = range.getBoundingClientRect()
     setPendingTop(rangeRect.top - articleRect.top)
+    setPendingRects(
+      Array.from(range.getClientRects()).map((r) => ({
+        top: r.top - articleRect.top,
+        left: r.left - articleRect.left,
+        width: r.width,
+        height: r.height,
+      })),
+    )
   }, [pending, recomputeKey])
 
   // Handlers — keep optimistic UI: append/update local state, server is source on next reload
@@ -195,9 +218,10 @@ export function HighlightLayer({ postId, children }: HighlightLayerProps) {
   )
 
   const article = articleRef.current
-  const pendingPreview = pending
-    ? pending.exact.slice(0, 40) + (pending.exact.length > 40 ? '…' : '')
-    : ''
+  const cancelPending = useCallback(() => {
+    setPending(null)
+    setError(null)
+  }, [])
 
   return (
     <div className='relative mx-auto w-full max-w-7xl'>
@@ -209,6 +233,15 @@ export function HighlightLayer({ postId, children }: HighlightLayerProps) {
             highlight={h}
             articleEl={article}
             recomputeKey={recomputeKey}
+          />
+        ))}
+        {/* Pending highlight overlay: keeps the selected text visually highlighted
+            while the composer is open, after the native selection has been cleared. */}
+        {pendingRects.map((r, i) => (
+          <div
+            key={`pending-${i}`}
+            className='pointer-events-none absolute z-10 rounded-sm border-b-2 border-primary/60 bg-primary/15'
+            style={{ top: r.top, left: r.left, width: r.width, height: r.height }}
           />
         ))}
         <SelectionToolbar
@@ -226,18 +259,13 @@ export function HighlightLayer({ postId, children }: HighlightLayerProps) {
               className='absolute left-4 right-0'
               style={{ top: pendingTop }}
             >
-              <div className='rounded-lg border border-primary/40 bg-card p-2 shadow-sm'>
-                <div className='mb-2 text-xs text-muted-foreground'>
-                  Commenting on “{pendingPreview}”
-                </div>
+              <div className='rounded-lg shadow-lg'>
                 <CommentComposer
                   placeholder='Add a comment…'
                   submitLabel='Comment'
+                  initialName={displayName ?? ''}
                   onSubmit={handleSubmitNew}
-                  onCancel={() => {
-                    setPending(null)
-                    setError(null)
-                  }}
+                  onCancel={cancelPending}
                 />
                 {error && (
                   <div className='mt-2 rounded border border-destructive/30 bg-destructive/10 p-2 text-xs text-destructive'>
@@ -264,18 +292,13 @@ export function HighlightLayer({ postId, children }: HighlightLayerProps) {
       {/* Mobile (< lg): composer as a centered bottom sheet matching post body width. */}
       {pending && (
         <div className='fixed inset-x-0 bottom-0 z-50 px-4 pb-4 pt-2 lg:hidden'>
-          <div className='mx-auto max-w-3xl rounded-lg border border-border bg-card p-3 shadow-lg'>
-            <div className='mb-2 text-xs text-muted-foreground'>
-              Commenting on “{pendingPreview}”
-            </div>
+          <div className='mx-auto max-w-3xl rounded-lg shadow-lg'>
             <CommentComposer
               placeholder='Add a comment…'
               submitLabel='Comment'
+              initialName={displayName ?? ''}
               onSubmit={handleSubmitNew}
-              onCancel={() => {
-                setPending(null)
-                setError(null)
-              }}
+              onCancel={cancelPending}
             />
             {error && (
               <div className='mt-2 rounded border border-destructive/30 bg-destructive/10 p-2 text-xs text-destructive'>

--- a/components/Highlights/Reactions.tsx
+++ b/components/Highlights/Reactions.tsx
@@ -13,7 +13,7 @@ interface ReactionsProps {
 
 export function Reactions({ reactions, fingerprint, onToggle, disabled }: ReactionsProps) {
   return (
-    <div className='flex flex-wrap items-center gap-1'>
+    <div className='-ml-1 flex flex-wrap items-center gap-1'>
       {QUICK_EMOJI.map((emoji) => {
         const fps = reactions[emoji] ?? []
         const count = fps.length
@@ -25,17 +25,17 @@ export function Reactions({ reactions, fingerprint, onToggle, disabled }: Reacti
             onClick={() => onToggle(emoji)}
             disabled={disabled}
             className={[
-              'inline-flex h-6 items-center gap-1 rounded-full border px-1.5 text-[11px] transition-colors',
+              'inline-flex items-center gap-1 rounded px-1.5 py-0.5 leading-none transition-colors',
               reacted
-                ? 'border-primary/40 bg-primary/10 text-primary'
-                : 'border-border bg-card text-muted-foreground hover:bg-muted',
+                ? 'bg-primary/10 text-primary'
+                : 'text-muted-foreground hover:bg-muted',
               disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer',
             ].join(' ')}
             aria-pressed={reacted}
             aria-label={`React with ${emoji}`}
           >
-            <span>{emoji}</span>
-            {count > 0 && <span>{count}</span>}
+            <span className='text-base'>{emoji}</span>
+            {count > 0 && <span className='text-xs tabular-nums'>{count}</span>}
           </button>
         )
       })}

--- a/lib/highlights/clientApi.ts
+++ b/lib/highlights/clientApi.ts
@@ -33,6 +33,8 @@ async function request<T>(url: string, init?: RequestInit): Promise<T> {
 
 export interface HighlightsLoadResponse extends PostHighlights {
   currentFingerprint: string
+  /** Logged-in user's display name (GitHub username) — null when anonymous. */
+  currentDisplayName: string | null
   isOwner: boolean
 }
 

--- a/lib/highlights/server.ts
+++ b/lib/highlights/server.ts
@@ -84,6 +84,16 @@ export async function getOwnerToken(): Promise<string | undefined> {
 }
 
 /**
+ * GitHub username (or display name) of the currently logged-in user, if
+ * any. Used to attribute comments by name when the form's `authorName`
+ * field is empty but the user is signed in.
+ */
+export async function getSessionDisplayName(): Promise<string | null> {
+  const session = await getSession()
+  return session?.user?.username ?? session?.user?.name ?? null
+}
+
+/**
  * Parse + validate JSON body. Returns the parsed value, or throws an
  * `ApiBodyError` with a useful message that callers can convert to 400.
  */


### PR DESCRIPTION
## Summary

Four polish items from the second round of live feedback:

### 1. Selection visually persists, redundant header gone
**Before**: clicking "+" cleared the native selection and the composer showed "Commenting on '...'" — the user lost the highlight on the text but kept it as duplicated quoted text in the composer header.

**After**: the selected range gets a primary-tinted overlay (rendered the same way as a saved highlight) that persists for as long as the composer is open. The "Commenting on" header is removed — the visual highlight on the article *is* the context.

### 2. Composer breathing space
`gap-2` / `p-3` / `py-1.5` squeezed the textarea, name field, and buttons. Bumped to `gap-3` / `p-4` / `py-2` with `h-8` buttons. Reads as a card now, not a stack of crammed inputs.

### 3. Logged-in users get their name (not "Anonymous")
The API never checked NextAuth, so signed-in users got "Anonymous {fp}" against their own comments.

**Server**: `GET /highlights` now returns `currentDisplayName` (the session's GitHub username). `POST /highlights` + `POST /replies` fall back to that when `body.authorName` is empty.

**Client**: `HighlightLayer` reads `currentDisplayName` and pre-fills the composer's name field. `CommentComposer` syncs with `initialName` until the user types their own value (handles async session load after mount).

> **Re "are anonymous IDs unique?"** Yes — the fingerprint is already
> `{hashedIP}_{country}_{platform}_{uaHash}`, so different visitors get different
> handles. The "29fb" in the screenshot was the same browser commenting twice.

### 4. Reactions: no more pill borders
Stripped the circular border + rounded-full styling that read like sticker badges. Now: `text-base` emoji, `text-xs tabular-nums` count, hover tints with `bg-muted`. Active state is a soft `bg-primary/10` background. Looks like inline reactions, not labels.

## Files changed (7, +97 / -37)

- `lib/highlights/server.ts` — new `getSessionDisplayName()` helper
- `lib/highlights/clientApi.ts` — `HighlightsLoadResponse` adds `currentDisplayName`
- `app/api/blog/[id]/highlights/route.ts` — GET returns name, POST falls back to it
- `app/api/blog/[id]/highlights/[hid]/replies/route.ts` — POST falls back to it
- `components/Highlights/HighlightLayer.tsx` — pending overlay rects, drop "Commenting on" header, pass `displayName` to composer
- `components/Highlights/CommentComposer.tsx` — breathing room, sync `initialName` while untouched
- `components/Highlights/Reactions.tsx` — flatter, no border

## Test plan

- [ ] **Select + comment**: select text, click "+", composer opens. The selected text stays highlighted (primary tint) for as long as the composer is open. No "Commenting on '...'" header.
- [ ] **Logged-in flow**: log in via GitHub. Open composer — name field pre-filled with your GitHub username. Submit. Comment shows your username (not "Anonymous").
- [ ] **Anonymous flow**: log out. Open composer — name field empty (placeholder "Your name (optional)"). Submit without filling name. Comment shows "Anonymous {fp4}".
- [ ] **Different anonymous browsers**: open in another browser/profile, comment without name. Different `{fp4}` handle.
- [ ] **Reactions**: hover/click — emoji is larger, no circles, count next to it. Active state is a soft tinted background.
- [ ] **Spacing**: composer feels breathable, not cramped.

Local verification was blocked by network instability during the session (npm reify hung repeatedly). Relying on CI.