### PR TITLE
fix(highlights): proper rail spacing, owner can delete, drop emoji bar

### DIFF
--- a/components/Highlights/CommentCard.tsx
+++ b/components/Highlights/CommentCard.tsx
@@ -4,11 +4,10 @@ import { formatDistanceToNow } from 'date-fns'
 import { Trash2, CheckCircle, RotateCcw } from 'lucide-react'
 import { useState } from 'react'
 
-import { Highlight, InlineComment, Reactions as ReactionsT } from '@/lib/highlights/schema'
+import { Highlight, InlineComment } from '@/lib/highlights/schema'
 import { setFocused, useFocusedHighlight } from '@/lib/highlights/syncFocus'
 
 import { CommentComposer } from './CommentComposer'
-import { Reactions } from './Reactions'
 
 interface CommentCardProps {
   highlight: Highlight
@@ -29,11 +28,20 @@ interface CommentCardProps {
  * Renders one highlight's thread as a Google Docs-style card. The thread's
  * first comment is the root; the rest render indented as replies. A reply
  * composer lives at the bottom and reveals on click.
+ *
+ * NOTE: emoji reactions are intentionally hidden in the UI — the API and
+ * data model still support them, but the visible bar was clashing with
+ * the site's voice. Re-enable by importing/rendering `<Reactions>`.
  */
 export function CommentCard(props: CommentCardProps) {
   const { highlight, fingerprint, isOwner, onReply, onReact, onResolve, onDelete } = props
   const focused = useFocusedHighlight() === highlight.id
   const [replyOpen, setReplyOpen] = useState(false)
+
+  // `fingerprint` and `onReact` are still threaded through for when reactions
+  // are re-enabled. Suppress unused warnings cleanly.
+  void fingerprint
+  void onReact
 
   const root = highlight.thread[0]
   const replies = highlight.thread.slice(1)
@@ -49,8 +57,7 @@ export function CommentCard(props: CommentCardProps) {
         highlight.resolved ? 'opacity-60' : '',
       ].join(' ')}
     >
-      <CommentBody comment={root} fingerprint={fingerprint} isOwner={isOwner}
-        onReact={(emoji) => onReact(highlight.id, root.id, emoji)}
+      <CommentBody comment={root} isOwner={isOwner}
         onDelete={() => onDelete(highlight.id, root.id)}
       />
 
@@ -60,9 +67,7 @@ export function CommentCard(props: CommentCardProps) {
             <CommentBody
               key={reply.id}
               comment={reply}
-              fingerprint={fingerprint}
               isOwner={isOwner}
-              onReact={(emoji) => onReact(highlight.id, reply.id, emoji)}
               onDelete={() => onDelete(highlight.id, reply.id)}
               compact
             />
@@ -81,25 +86,15 @@ export function CommentCard(props: CommentCardProps) {
           </button>
         )}
         {isOwner && (
-          <div className='ml-auto flex items-center gap-1'>
-            <button
-              type='button'
-              onClick={() => onResolve(highlight.id, !highlight.resolved)}
-              className='inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs text-muted-foreground hover:bg-muted'
-              aria-label={highlight.resolved ? 'Reopen' : 'Resolve'}
-            >
-              {highlight.resolved ? <RotateCcw className='h-3 w-3' /> : <CheckCircle className='h-3 w-3' />}
-              {highlight.resolved ? 'Reopen' : 'Resolve'}
-            </button>
-            <button
-              type='button'
-              onClick={() => onDelete(highlight.id)}
-              className='inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs text-destructive hover:bg-destructive/10'
-              aria-label='Delete highlight'
-            >
-              <Trash2 className='h-3 w-3' />
-            </button>
-          </div>
+          <button
+            type='button'
+            onClick={() => onResolve(highlight.id, !highlight.resolved)}
+            className='ml-auto inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs text-muted-foreground hover:bg-muted'
+            aria-label={highlight.resolved ? 'Reopen' : 'Resolve'}
+          >
+            {highlight.resolved ? <RotateCcw className='h-3 w-3' /> : <CheckCircle className='h-3 w-3' />}
+            {highlight.resolved ? 'Reopen' : 'Resolve'}
+          </button>
         )}
       </div>
 
@@ -122,16 +117,12 @@ export function CommentCard(props: CommentCardProps) {
 
 function CommentBody({
   comment,
-  fingerprint,
   isOwner,
-  onReact,
   onDelete,
   compact,
 }: {
   comment: InlineComment
-  fingerprint: string | null
   isOwner: boolean
-  onReact: (emoji: string) => Promise<void>
   onDelete: () => Promise<void>
   compact?: boolean
 }) {
@@ -149,12 +140,12 @@ function CommentBody({
           <span className='font-medium text-foreground'>{displayName}</span>
           <span className='text-[11px] text-muted-foreground'>· {time}</span>
         </div>
-        {isOwner && compact && (
+        {isOwner && (
           <button
             type='button'
             onClick={onDelete}
-            className='text-[11px] text-destructive hover:underline'
-            aria-label='Delete reply'
+            className='rounded p-1 text-muted-foreground hover:bg-muted hover:text-destructive'
+            aria-label={compact ? 'Delete reply' : 'Delete comment'}
           >
             <Trash2 className='h-3 w-3' />
           </button>
@@ -162,15 +153,6 @@ function CommentBody({
       </div>
       <div className='mt-1 whitespace-pre-wrap text-foreground/80'>
         {comment.body}
-      </div>
-      <div className='mt-1.5'>
-        <Reactions
-          reactions={comment.reactions as ReactionsT}
-          fingerprint={fingerprint}
-          onToggle={(emoji) => {
-            void onReact(emoji)
-          }}
-        />
       </div>
     </div>
   )

--- a/components/Highlights/HighlightLayer.tsx
+++ b/components/Highlights/HighlightLayer.tsx
@@ -224,8 +224,8 @@ export function HighlightLayer({ postId, children }: HighlightLayerProps) {
   }, [])
 
   return (
-    <div className='relative mx-auto w-full max-w-7xl'>
-      <div ref={articleRef} className='relative'>
+    <div className='relative mx-auto w-full lg:flex lg:max-w-6xl lg:items-start lg:gap-12 lg:px-6'>
+      <div ref={articleRef} className='relative w-full lg:max-w-3xl lg:flex-1'>
         {children}
         {highlights.map((h) => (
           <HighlightMark
@@ -251,12 +251,14 @@ export function HighlightLayer({ postId, children }: HighlightLayerProps) {
         />
       </div>
 
-      {/* Right-rail (lg+): composer at the selection's vertical top, plus existing cards. */}
-      <aside className='absolute right-0 top-0 hidden w-72 lg:block'>
-        <div className='relative pl-4'>
+      {/* Right-rail (lg+): composer at the selection's vertical top, plus existing cards.
+          Sibling of the article in flex flow — gap-12 on the parent gives the
+          breathing room. */}
+      <aside className='hidden w-72 shrink-0 lg:block'>
+        <div className='relative'>
           {pending && pendingTop !== null && (
             <div
-              className='absolute left-4 right-0'
+              className='absolute left-0 right-0'
               style={{ top: pendingTop }}
             >
               <div className='rounded-lg shadow-lg'>

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -37,12 +37,24 @@ export const authOptions: NextAuthOptions = {
     }),
   ],
   callbacks: {
-    async jwt({ token, account }) {
+    async jwt({ token, account, profile }) {
       if (account && account.access_token) {
         token.accessToken = account.access_token
       }
-      if (account) {
-        token.username = account.username
+      // GitHub OAuth puts the login (username) on the `profile` object, not
+      // on `account`. Capture it here so `session.user.username` is reliable
+      // for owner-check logic. Falls back to whatever was on `account`
+      // for compatibility with the previous behavior.
+      const profileLogin =
+        profile && typeof profile === 'object' && 'login' in profile
+          ? (profile as { login?: string }).login
+          : undefined
+      const accountUsername =
+        account && typeof account === 'object' && 'username' in account
+          ? (account as { username?: string }).username
+          : undefined
+      if (profileLogin || accountUsername) {
+        token.username = profileLogin ?? accountUsername
       }
       return token
     },


### PR DESCRIPTION
## Summary

Three live-feedback items from comparing #83's deploy to your design intent.

### 1. No breathing space between article and rail

The old layout was `max-w-7xl mx-auto` with the rail `absolute right-0`. On any viewport narrower than ~1408px (i.e. most laptops), the rail's left edge sat *inside* the article's right edge — zero gap, often visual overlap.

**Fix**: outer container is now `lg:flex lg:max-w-6xl lg:gap-12 lg:px-6 lg:items-start`. Article + rail are flex siblings with `gap-12` (48px) between them. Below `lg`, single column with the bottom-sheet composer as before.

```
[ article (max-w-3xl, flex-1) ] [ 48px gap ] [ rail (w-72) ]
                  └────── max-w-6xl, lg:px-6 ──────┘
```

### 2. Owner couldn't delete comments

The bug was in `lib/auth.ts`: the JWT callback was reading `account.username`, but **GitHub OAuth doesn't put the login on `account`** — it lives on `profile`. So `session.user.username` was always `undefined`, and `isOwner()` always returned `false`. The recent display-name UX still worked because `getSessionDisplayName()` falls back to `session.user.name` (the GitHub display name like "Minghe").

**Fix**: JWT callback now reads `profile.login` (with `account.username` as a defensive fallback). `isOwner()` works.

Plus a UX restructure: a small trash icon now sits in the header of **every** comment (root and reply) when the owner is signed in. Uniform "delete any comment" affordance. The redundant footer "Delete" button is gone — Resolve/Reopen stays in the footer.

### 3. Emoji bar removed

Reactions clashed with the site's voice. Removed the rendered bar.

The API endpoints, the `reactions` field on the schema, and the `<Reactions>` component are all still in place — re-enabling is one import + one render call away. `fingerprint` and `onReact` props remain threaded through `CommentCard` for that.

## Files changed (3, +46 / -50)

- `lib/auth.ts` — JWT callback reads `profile.login`
- `components/Highlights/HighlightLayer.tsx` — flex layout with `gap-12`
- `components/Highlights/CommentCard.tsx` — per-comment delete trash, drop emoji bar, drop redundant footer Delete

## Test plan

- [ ] **Spacing**: visually confirm there's a clear gap between the article body and the comment cards on a laptop-sized viewport (1024–1440 width).
- [ ] **Owner delete**: log in via GitHub. Each comment (root and reply) should now show a small trash icon at the right of its header. Clicking deletes that single comment. Footer still shows "Resolve / Reopen".
- [ ] **Anonymous reader**: log out. Trash icons disappear; only the Reply button is visible at the bottom of each thread.
- [ ] **No emojis**: comment bodies no longer show 👍 ❤️ 🎉 🤔 👀 row.
- [ ] **Existing reactions data**: pre-existing reactions in `data/highlights/*.json` are preserved on disk (not deleted from the schema, just not displayed).

Local verification was blocked by network instability during this session (npm reify hung repeatedly). Relying on CI.