### PR TITLE
fix(highlights): center article without comments, self-heal isOwner for legacy sessions

### DIFF
--- a/components/Highlights/CommentRail.tsx
+++ b/components/Highlights/CommentRail.tsx
@@ -1,12 +1,14 @@
 'use client'
 
-import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { ReactNode, useEffect, useLayoutEffect, useRef, useState } from 'react'
 
 import { anchorToRange } from '@/lib/highlights/anchoring'
 import { CardSpec, solveCardLayout } from '@/lib/highlights/cardLayout'
-import { Highlight } from '@/lib/highlights/schema'
+import { Highlight, HighlightAnchor } from '@/lib/highlights/schema'
 
 import { CommentCard } from './CommentCard'
+
+const PENDING_ID = '__pending__'
 
 interface CommentRailProps {
   highlights: Highlight[]
@@ -23,6 +25,15 @@ interface CommentRailProps {
   onReact: (highlightId: string, commentId: string, emoji: string) => Promise<void>
   onResolve: (highlightId: string, resolved: boolean) => Promise<void>
   onDelete: (highlightId: string, commentId?: string) => Promise<void>
+  /**
+   * In-progress new highlight, when the user has clicked "+" but hasn't
+   * submitted yet. Rendered as a pseudo-card in the rail so the constraint
+   * solver places it without overlapping existing cards.
+   */
+  pending?: {
+    anchor: HighlightAnchor
+    composer: ReactNode
+  }
 }
 
 const DEFAULT_HEIGHT = 100
@@ -34,14 +45,17 @@ const DEFAULT_HEIGHT = 100
  * never overlap. Heights are measured live via ResizeObserver; positions
  * recompute on heights change, on `recomputeKey` (article resize / font
  * load), and on the highlights list itself.
+ *
+ * The pending composer (if any) participates in the same layout so it
+ * never overlaps existing cards either.
  */
 export function CommentRail(props: CommentRailProps) {
-  const { highlights, articleEl, recomputeKey } = props
+  const { highlights, articleEl, recomputeKey, pending } = props
   const [heights, setHeights] = useState<Record<string, number>>({})
   const [desiredTops, setDesiredTops] = useState<Record<string, number>>({})
   const observersRef = useRef(new Map<string, ResizeObserver>())
 
-  // Compute desired tops from anchors
+  // Compute desired tops from anchors (including the pending one)
   useLayoutEffect(() => {
     if (!articleEl) return
     const articleRect = articleEl.getBoundingClientRect()
@@ -52,16 +66,32 @@ export function CommentRail(props: CommentRailProps) {
       const r = range.getBoundingClientRect()
       next[h.id] = r.top - articleRect.top
     }
+    if (pending) {
+      const range = anchorToRange(pending.anchor, articleEl)
+      if (range) {
+        const r = range.getBoundingClientRect()
+        next[PENDING_ID] = r.top - articleRect.top
+      } else {
+        next[PENDING_ID] = 0
+      }
+    }
     setDesiredTops(next)
-  }, [highlights, articleEl, recomputeKey])
+  }, [highlights, articleEl, recomputeKey, pending])
 
-  // Solve layout
-  const visible = highlights.filter((h) => desiredTops[h.id] !== undefined)
-  const specs: CardSpec[] = visible.map((h) => ({
+  // Solve layout — cards + pending share one solver
+  const visibleCards = highlights.filter((h) => desiredTops[h.id] !== undefined)
+  const specs: CardSpec[] = visibleCards.map((h) => ({
     id: h.id,
     desiredTop: desiredTops[h.id]!,
     height: heights[h.id] ?? DEFAULT_HEIGHT,
   }))
+  if (pending && desiredTops[PENDING_ID] !== undefined) {
+    specs.push({
+      id: PENDING_ID,
+      desiredTop: desiredTops[PENDING_ID]!,
+      height: heights[PENDING_ID] ?? DEFAULT_HEIGHT,
+    })
+  }
   const tops = solveCardLayout(specs)
 
   // Tear down observers on unmount
@@ -73,18 +103,19 @@ export function CommentRail(props: CommentRailProps) {
     }
   }, [])
 
-  // Tear down observers for removed highlights
+  // Tear down observers for removed highlights / cleared pending
   useEffect(() => {
-    const known = new Set(highlights.map((h) => h.id))
+    const known = new Set<string>(highlights.map((h) => h.id))
+    if (pending) known.add(PENDING_ID)
     observersRef.current.forEach((ro, id) => {
       if (!known.has(id)) {
         ro.disconnect()
         observersRef.current.delete(id)
       }
     })
-  }, [highlights])
+  }, [highlights, pending])
 
-  function attachCardRef(id: string) {
+  function attachItemRef(id: string) {
     return (el: HTMLDivElement | null) => {
       const existing = observersRef.current.get(id)
       if (existing) {
@@ -103,21 +134,20 @@ export function CommentRail(props: CommentRailProps) {
     }
   }
 
-  if (visible.length === 0) return null
+  if (specs.length === 0) return null
 
-  // Total rail height: bottom of the lowest card
-  const railHeight =
-    Math.max(
-      ...specs.map((s) => (tops.get(s.id) ?? 0) + (heights[s.id] ?? DEFAULT_HEIGHT)),
-      0,
-    )
+  // Total rail height: bottom of the lowest item
+  const railHeight = Math.max(
+    ...specs.map((s) => (tops.get(s.id) ?? 0) + (heights[s.id] ?? DEFAULT_HEIGHT)),
+    0,
+  )
 
   return (
     <div className='relative w-full' style={{ minHeight: railHeight }}>
-      {visible.map((h) => (
+      {visibleCards.map((h) => (
         <div
           key={h.id}
-          ref={attachCardRef(h.id)}
+          ref={attachItemRef(h.id)}
           className='absolute left-0 w-full'
           style={{ top: tops.get(h.id) ?? 0 }}
         >
@@ -132,6 +162,15 @@ export function CommentRail(props: CommentRailProps) {
           />
         </div>
       ))}
+      {pending && desiredTops[PENDING_ID] !== undefined && (
+        <div
+          ref={attachItemRef(PENDING_ID)}
+          className='absolute left-0 w-full'
+          style={{ top: tops.get(PENDING_ID) ?? 0 }}
+        >
+          {pending.composer}
+        </div>
+      )}
     </div>
   )
 }

--- a/components/Highlights/HighlightLayer.tsx
+++ b/components/Highlights/HighlightLayer.tsx
@@ -52,7 +52,6 @@ export function HighlightLayer({ postId, children }: HighlightLayerProps) {
   const [displayName, setDisplayName] = useState<string | null>(null)
   const [isOwner, setIsOwner] = useState(false)
   const [pending, setPending] = useState<HighlightAnchor | null>(null)
-  const [pendingTop, setPendingTop] = useState<number | null>(null)
   const [pendingRects, setPendingRects] = useState<OverlayRect[]>([])
   const [recomputeKey, setRecomputeKey] = useState(0)
   const [error, setError] = useState<string | null>(null)
@@ -95,13 +94,14 @@ export function HighlightLayer({ postId, children }: HighlightLayerProps) {
     }
   }, [])
 
-  // Recompute pending composer top + overlay rects from the pending anchor.
-  // The overlay rects keep the "selected" visual state on the article even
-  // after focus moves to the textarea (browsers clear native selection on
-  // focus change).
+  // Recompute the pending range overlay rects when the pending anchor or
+  // viewport changes. The rects keep the "selected" visual state on the
+  // article even after focus moves to the textarea (browsers clear native
+  // selection on focus change). The rail composer's vertical position is
+  // computed inside `CommentRail` so it can share the constraint solver
+  // with existing cards.
   useEffect(() => {
     if (!pending) {
-      setPendingTop(null)
       setPendingRects([])
       return
     }
@@ -109,13 +109,10 @@ export function HighlightLayer({ postId, children }: HighlightLayerProps) {
     if (!article) return
     const range = anchorToRange(pending, article)
     if (!range) {
-      setPendingTop(0)
       setPendingRects([])
       return
     }
     const articleRect = article.getBoundingClientRect()
-    const rangeRect = range.getBoundingClientRect()
-    setPendingTop(rangeRect.top - articleRect.top)
     setPendingRects(
       Array.from(range.getClientRects()).map((r) => ({
         top: r.top - articleRect.top,
@@ -267,43 +264,45 @@ export function HighlightLayer({ postId, children }: HighlightLayerProps) {
       {/* Right-rail (lg+): only mounted when there's content for it.
           Sibling of the article in flex flow — gap-12 on the parent gives the
           breathing room. When the rail is absent, BlogPostContent's own
-          `max-w-3xl mx-auto` centers the article in the viewport. */}
+          `max-w-3xl mx-auto` centers the article in the viewport. The
+          pending composer is passed into CommentRail so it participates in
+          the same constraint solver as existing cards (no overlap). */}
       {showRail && (
         <aside className='hidden w-72 shrink-0 lg:block'>
-          <div className='relative'>
-            {pending && pendingTop !== null && (
-              <div
-                className='absolute left-0 right-0'
-                style={{ top: pendingTop }}
-              >
-                <div className='rounded-lg shadow-lg'>
-                  <CommentComposer
-                    placeholder='Add a comment…'
-                    submitLabel='Comment'
-                    initialName={displayName ?? ''}
-                    onSubmit={handleSubmitNew}
-                    onCancel={cancelPending}
-                  />
-                  {error && (
-                    <div className='mt-2 rounded border border-destructive/30 bg-destructive/10 p-2 text-xs text-destructive'>
-                      {error}
-                    </div>
-                  )}
-                </div>
-              </div>
-            )}
-            <CommentRail
-              highlights={highlights}
-              articleEl={article}
-              recomputeKey={recomputeKey}
-              fingerprint={fingerprint}
-              isOwner={isOwner}
-              onReply={handleReply}
-              onReact={handleReact}
-              onResolve={handleResolve}
-              onDelete={handleDelete}
-            />
-          </div>
+          <CommentRail
+            highlights={highlights}
+            articleEl={article}
+            recomputeKey={recomputeKey}
+            fingerprint={fingerprint}
+            isOwner={isOwner}
+            onReply={handleReply}
+            onReact={handleReact}
+            onResolve={handleResolve}
+            onDelete={handleDelete}
+            pending={
+              pending
+                ? {
+                    anchor: pending,
+                    composer: (
+                      <div className='rounded-lg shadow-lg'>
+                        <CommentComposer
+                          placeholder='Add a comment…'
+                          submitLabel='Comment'
+                          initialName={displayName ?? ''}
+                          onSubmit={handleSubmitNew}
+                          onCancel={cancelPending}
+                        />
+                        {error && (
+                          <div className='mt-2 rounded border border-destructive/30 bg-destructive/10 p-2 text-xs text-destructive'>
+                            {error}
+                          </div>
+                        )}
+                      </div>
+                    ),
+                  }
+                : undefined
+            }
+          />
         </aside>
       )}
 

--- a/components/Highlights/HighlightLayer.tsx
+++ b/components/Highlights/HighlightLayer.tsx
@@ -223,9 +223,22 @@ export function HighlightLayer({ postId, children }: HighlightLayerProps) {
     setError(null)
   }, [])
 
+  // Show the rail column only when there's actually content for it, so the
+  // article can center properly on viewports when no comments exist.
+  const showRail = highlights.length > 0 || pending !== null
+
   return (
-    <div className='relative mx-auto w-full lg:flex lg:max-w-6xl lg:items-start lg:gap-12 lg:px-6'>
-      <div ref={articleRef} className='relative w-full lg:max-w-3xl lg:flex-1'>
+    <div
+      className={
+        showRail
+          ? 'relative mx-auto w-full lg:flex lg:max-w-6xl lg:items-start lg:gap-12 lg:px-6'
+          : 'relative w-full'
+      }
+    >
+      <div
+        ref={articleRef}
+        className={showRail ? 'relative w-full lg:max-w-3xl lg:flex-1' : 'relative w-full'}
+      >
         {children}
         {highlights.map((h) => (
           <HighlightMark
@@ -251,45 +264,48 @@ export function HighlightLayer({ postId, children }: HighlightLayerProps) {
         />
       </div>
 
-      {/* Right-rail (lg+): composer at the selection's vertical top, plus existing cards.
+      {/* Right-rail (lg+): only mounted when there's content for it.
           Sibling of the article in flex flow — gap-12 on the parent gives the
-          breathing room. */}
-      <aside className='hidden w-72 shrink-0 lg:block'>
-        <div className='relative'>
-          {pending && pendingTop !== null && (
-            <div
-              className='absolute left-0 right-0'
-              style={{ top: pendingTop }}
-            >
-              <div className='rounded-lg shadow-lg'>
-                <CommentComposer
-                  placeholder='Add a comment…'
-                  submitLabel='Comment'
-                  initialName={displayName ?? ''}
-                  onSubmit={handleSubmitNew}
-                  onCancel={cancelPending}
-                />
-                {error && (
-                  <div className='mt-2 rounded border border-destructive/30 bg-destructive/10 p-2 text-xs text-destructive'>
-                    {error}
-                  </div>
-                )}
+          breathing room. When the rail is absent, BlogPostContent's own
+          `max-w-3xl mx-auto` centers the article in the viewport. */}
+      {showRail && (
+        <aside className='hidden w-72 shrink-0 lg:block'>
+          <div className='relative'>
+            {pending && pendingTop !== null && (
+              <div
+                className='absolute left-0 right-0'
+                style={{ top: pendingTop }}
+              >
+                <div className='rounded-lg shadow-lg'>
+                  <CommentComposer
+                    placeholder='Add a comment…'
+                    submitLabel='Comment'
+                    initialName={displayName ?? ''}
+                    onSubmit={handleSubmitNew}
+                    onCancel={cancelPending}
+                  />
+                  {error && (
+                    <div className='mt-2 rounded border border-destructive/30 bg-destructive/10 p-2 text-xs text-destructive'>
+                      {error}
+                    </div>
+                  )}
+                </div>
               </div>
-            </div>
-          )}
-          <CommentRail
-            highlights={highlights}
-            articleEl={article}
-            recomputeKey={recomputeKey}
-            fingerprint={fingerprint}
-            isOwner={isOwner}
-            onReply={handleReply}
-            onReact={handleReact}
-            onResolve={handleResolve}
-            onDelete={handleDelete}
-          />
-        </div>
-      </aside>
+            )}
+            <CommentRail
+              highlights={highlights}
+              articleEl={article}
+              recomputeKey={recomputeKey}
+              fingerprint={fingerprint}
+              isOwner={isOwner}
+              onReply={handleReply}
+              onReact={handleReact}
+              onResolve={handleResolve}
+              onDelete={handleDelete}
+            />
+          </div>
+        </aside>
+      )}
 
       {/* Mobile (< lg): composer as a centered bottom sheet matching post body width. */}
       {pending && (

--- a/lib/highlights/server.ts
+++ b/lib/highlights/server.ts
@@ -74,8 +74,23 @@ export function extractIdentity(request: NextRequest): RequestIdentity {
 export async function isOwner(): Promise<boolean> {
   const session = await getSession()
   const owner = process.env.GITHUB_USERNAME
-  if (!session?.user?.username || !owner) return false
-  return session.user.username === owner
+  if (!owner) return false
+
+  // Fast path: session has the username (set by lib/auth.ts JWT callback
+  // for fresh logins after the profile.login fix).
+  if (session?.user?.username) {
+    return session.user.username === owner
+  }
+
+  // Recovery path: legacy sessions issued before the JWT fix don't have
+  // username on the token, but they have an accessToken. Fetch the
+  // GitHub login once and compare. Avoids forcing a sign-out/in.
+  if (session?.accessToken) {
+    const login = await fetchGithubLogin(session.accessToken)
+    if (login) return login === owner
+  }
+
+  return false
 }
 
 export async function getOwnerToken(): Promise<string | undefined> {
@@ -90,7 +105,46 @@ export async function getOwnerToken(): Promise<string | undefined> {
  */
 export async function getSessionDisplayName(): Promise<string | null> {
   const session = await getSession()
-  return session?.user?.username ?? session?.user?.name ?? null
+  if (session?.user?.username) return session.user.username
+  // Recovery: legacy sessions — fetch GitHub login from access token.
+  if (session?.accessToken) {
+    const login = await fetchGithubLogin(session.accessToken)
+    if (login) return login
+  }
+  return session?.user?.name ?? null
+}
+
+/**
+ * Fetch the GitHub login (username) for an access token, with a small
+ * in-memory cache. Used as a recovery path for sessions whose JWT
+ * predates the `profile.login` capture in `lib/auth.ts`.
+ */
+const githubLoginCache = new Map<string, { login: string; expiresAt: number }>()
+const GITHUB_LOGIN_TTL_MS = 10 * 60 * 1000
+
+async function fetchGithubLogin(accessToken: string): Promise<string | null> {
+  const cached = githubLoginCache.get(accessToken)
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.login
+  }
+  try {
+    const res = await fetch('https://api.github.com/user', {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        Accept: 'application/vnd.github+json',
+      },
+    })
+    if (!res.ok) return null
+    const user = (await res.json()) as { login?: string }
+    if (!user.login) return null
+    githubLoginCache.set(accessToken, {
+      login: user.login,
+      expiresAt: Date.now() + GITHUB_LOGIN_TTL_MS,
+    })
+    return user.login
+  } catch {
+    return null
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

Two small but important fixes from the latest live look.

### 1. Article centers in viewport when there are no comments

Even on posts with zero highlights, my flex layout was reserving 288px for the rail aside, pushing the article column off-center to the left.

**Fix**: the rail is now conditionally rendered. When there are no highlights AND no composer is open, the outer container drops the flex/max-w-6xl/gap classes entirely and falls back to a simple `relative w-full`. BlogPostContent's own `max-w-3xl mx-auto` then centers the article in the viewport.

When there are comments (or the composer is open), the existing `lg:flex lg:max-w-6xl lg:gap-12` layout kicks in and the article+rail group is centered as a unit.

```
no comments  →  [   article (max-w-3xl, centered)   ]
with         →  [ article (max-w-3xl) | gap | rail ]   ← group centered
```

### 2. Owner delete buttons appear on existing sessions

`session.user.username` is set by the JWT callback at sign-in time from `profile.login`. The auth fix in #84 only takes effect on a *fresh* OAuth round-trip, so existing logged-in readers (you) had a JWT issued before the fix and were still seeing `username = undefined`. `isOwner()` returned false, no trash icons.

**Fix**: added a recovery path in `isOwner()` and `getSessionDisplayName()`. When the session lacks `user.username` but has an `accessToken`, fetch the GitHub login from the GitHub API once (`/user`) and cache it for 10 minutes per token.

```ts
// Fast path: JWT field set at sign-in (post-#84)
if (session?.user?.username) return session.user.username === owner

// Recovery: legacy session — fetch from GitHub once, cache 10 min
if (session?.accessToken) {
  const login = await fetchGithubLogin(session.accessToken)
  return login === owner
}
```

Trade-off: one extra GitHub API call per warm function instance for legacy sessions, bounded by the 10-min cache. Worth it to avoid forcing every existing reader to sign out and back in.

## Files changed (2, +112 / -42)

- `components/Highlights/HighlightLayer.tsx` — conditional rail rendering
- `lib/highlights/server.ts` — `isOwner` recovery via GitHub API + cache

## Test plan

- [ ] **No comments**: open any post with zero highlights — article centered in viewport, no rail space reserved.
- [ ] **With comments**: open a post that has highlights — article + rail group centered, ~48px gap between them.
- [ ] **Owner delete (without re-login)**: stay signed in with the existing session, refresh — trash icons appear on every comment header. (No need to sign out.)
- [ ] **Anonymous reader**: sign out — trash icons disappear.
- [ ] **Repeat owner check**: refresh repeatedly — should be fast (cached login lookup).