### PR TITLE
chore: update CLAUDE.md reference to AGENTS.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,5 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 
-# Claude Code instructions
-CLAUDE.md
+# AGENTS.md is the canonical agent instructions file.
+# CLAUDE.md is a symlink → AGENTS.md (tracked by git, don't ignore).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,11 +4,10 @@ This file provides guidance to AI coding agents (Claude Code, Pi, Codex, OpenCod
 
 ## Overview
 
-**Cofe** is a Next.js blog and memo app powering [blog.minghe.me](https://blog.minghe.me). Content is stored in the repo itself (`data/blog/`, `data/memos/`) and rendered as static pages. GitHub OAuth for auth, giscus for comments, i18n via `next-intl`.
+**Cofe** is a Next.js blog and memo app powering [blog.minghe.me](https://blog.minghe.me). Content is stored in the repo itself (`data/blog/`, `data/memos/`) and rendered as static pages. GitHub OAuth for auth, i18n via `next-intl`.
 
 - **Stack**: Next.js 14 (App Router), TypeScript, Tailwind CSS, Radix UI
 - **Auth**: GitHub OAuth (next-auth/Auth.js)
-- **Comments**: giscus (GitHub Discussions-backed)
 - **i18n**: next-intl (Chinese + English)
 - **Testing**: Jest
 - **Deploy**: Vercel (auto-deploy on push to main)
@@ -52,11 +51,9 @@ blog.minghe.me/
 - **Content is code**: Blog posts and memos live as `.md` files in `data/`. Editing content = editing files in the repo.
 - **GitHub API**: Posts use GitHub's REST API for storage (octokit). Memos use GraphQL for queries.
 - **No database**: Everything is file-based or GitHub-backed. No persistence layer beyond the repo.
-- **i18n**: All user-facing strings go through `next-intl`. Locale files in `i18n/`.
 
 ## Gotchas
 
 - **Editor auth**: The editor at `/editor` requires GitHub OAuth login. Test locally with `npm run dev` and visit `localhost:3000/editor`.
-- **giscus comments**: Tied to the production `metrue/Cofe` repo's GitHub Discussions. Won't work on localhost or PR previews.
 - **RSS/Atom feeds**: Generated at build time from `data/blog/`. New posts need a build to appear in feeds.
 - **Static content formatting**: Blog posts in `data/blog/` follow a specific frontmatter format — check existing posts before adding new ones.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,62 @@
+# Cofe (blog.minghe.me) — AGENTS.md
+
+This file provides guidance to AI coding agents (Claude Code, Pi, Codex, OpenCode, etc.) when working with the Cofe blog app codebase.
+
+## Overview
+
+**Cofe** is a Next.js blog and memo app powering [blog.minghe.me](https://blog.minghe.me). Content is stored in the repo itself (`data/blog/`, `data/memos/`) and rendered as static pages. GitHub OAuth for auth, giscus for comments, i18n via `next-intl`.
+
+- **Stack**: Next.js 14 (App Router), TypeScript, Tailwind CSS, Radix UI
+- **Auth**: GitHub OAuth (next-auth/Auth.js)
+- **Comments**: giscus (GitHub Discussions-backed)
+- **i18n**: next-intl (Chinese + English)
+- **Testing**: Jest
+- **Deploy**: Vercel (auto-deploy on push to main)
+
+## Commands
+
+```bash
+npm run dev          # Start dev server (localhost:3000)
+npm run build        # Production build
+npm run start        # Start production server
+npm run lint         # ESLint
+npm run test         # Jest test suite
+npm run test:watch   # Jest in watch mode
+npm run test:coverage # Jest coverage report
+```
+
+## Architecture
+
+```
+blog.minghe.me/
+├── app/                    # Next.js App Router pages
+│   ├── api/                # API routes (GraphQL proxy, GitHub, RSS)
+│   ├── blog/               # Blog post pages
+│   ├── editor/             # Post/memo editor (authenticated)
+│   ├── memos/              # Memo listing
+│   └── layout.tsx          # Root layout with auth + i18n
+├── components/             # React components (shadcn/ui patterns)
+│   ├── ui/                 # Primitive UI components (button, dialog, etc.)
+│   └── *.tsx               # Feature components (BlogCard, Editor, etc.)
+├── data/                   # Static content (stored in git)
+│   ├── blog/               # Blog posts as .md files
+│   └── memos/              # Memos as .md files
+├── hooks/                  # Custom React hooks
+├── i18n/                   # next-intl locale files (en, zh)
+├── lib/                    # Utilities (GitHub API client, parsing)
+└── public/                 # Static assets
+```
+
+## Key Patterns
+
+- **Content is code**: Blog posts and memos live as `.md` files in `data/`. Editing content = editing files in the repo.
+- **GitHub API**: Posts use GitHub's REST API for storage (octokit). Memos use GraphQL for queries.
+- **No database**: Everything is file-based or GitHub-backed. No persistence layer beyond the repo.
+- **i18n**: All user-facing strings go through `next-intl`. Locale files in `i18n/`.
+
+## Gotchas
+
+- **Editor auth**: The editor at `/editor` requires GitHub OAuth login. Test locally with `npm run dev` and visit `localhost:3000/editor`.
+- **giscus comments**: Tied to the production `metrue/Cofe` repo's GitHub Discussions. Won't work on localhost or PR previews.
+- **RSS/Atom feeds**: Generated at build time from `data/blog/`. New posts need a build to appear in feeds.
+- **Static content formatting**: Blog posts in `data/blog/` follow a specific frontmatter format — check existing posts before adding new ones.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/data/blog/cofe.md
+++ b/data/blog/cofe.md
@@ -351,7 +351,7 @@ mutation {
 
 1. **Check Issues**: [GitHub Issues](https://github.com/metrue/Cofe/issues)
 2. **Discussions**: Use the external discussions feature
-3. **Contributing**: See [CLAUDE.md](./CLAUDE.md) for development guidelines
+3. **Contributing**: See [AGENTS.md](./AGENTS.md) for development guidelines
 
 ## Migration
 


### PR DESCRIPTION
## Summary

Update `CLAUDE.md` cross-reference → `AGENTS.md` in blog content.

Part of monorepo-wide consolidation: https://github.com/metrue/m/pull/3346