### PR TITLE
Adopt discussing 1.9.0 comment UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "clsx": "^2.1.1",
         "date-fns": "^3.6.0",
         "date-fns-tz": "^3.1.3",
-        "discussing": "^1.7.0",
+        "discussing": "^1.9.0",
         "graphql": "^16.11.0",
         "graphql-yoga": "^5.15.1",
         "gray-matter": "^4.0.3",
@@ -4792,9 +4792,10 @@
       }
     },
     "node_modules/discussing": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/discussing/-/discussing-1.7.0.tgz",
-      "integrity": "sha512-djQJGgZotM/ZhF3hOJvKJ9B3WzmvpyOMUJrc47uMITX8N2q1uI0r36yP5DzB7TT5u1+au/FPf31kOlLKIBgFpA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/discussing/-/discussing-1.9.0.tgz",
+      "integrity": "sha512-0mVcTSXY6W00h5tQm+teJvA5gSAvURkwz2sMY5oz8rzFAx9A60dQP/1tEbaJLB29ZqNkzDC3tXkMvIxO/nTung==",
+      "license": "MIT",
       "engines": {
         "node": ">=16.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "clsx": "^2.1.1",
     "date-fns": "^3.6.0",
     "date-fns-tz": "^3.1.3",
-    "discussing": "^1.7.0",
+    "discussing": "^1.8.0",
     "graphql": "^16.11.0",
     "graphql-yoga": "^5.15.1",
     "gray-matter": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "clsx": "^2.1.1",
     "date-fns": "^3.6.0",
     "date-fns-tz": "^3.1.3",
-    "discussing": "^1.8.0",
+    "discussing": "^1.9.0",
     "graphql": "^16.11.0",
     "graphql-yoga": "^5.15.1",
     "gray-matter": "^4.0.3",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,6 +8,9 @@ const config = {
  
     // Or if using `src` directory:
     './src/**/*.{js,ts,jsx,tsx,mdx}',
+
+    // Scan the `discussing` comment library so its Tailwind classes are generated.
+    './node_modules/discussing/dist/**/*.{js,mjs}',
   ],
   theme: {
   	extend: {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -5,6 +5,7 @@ const config: Config = {
     "./pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./components/**/*.{js,ts,jsx,tsx,mdx}",
     "./app/**/*.{js,ts,jsx,tsx,mdx}",
+    "./node_modules/discussing/dist/**/*.{js,mjs}",
   ],
   theme: {
     extend: {


### PR DESCRIPTION
## Summary

Adopts the redesigned comment UI from [`discussing` #10](https://github.com/metrue/discussing/pull/10), now published as **`discussing@1.9.0`**, and fixes a latent Tailwind config gap.

- **Bump `discussing` → `^1.9.0`** (lockfile refreshed to the published 1.9.0) — avatar-gutter comment thread, `@mention`/URL rendering, relative timestamps, collapsible long threads, dark-mode support.
  - Note: npm's `1.8.0` was an older build predating this redesign, so the new UI ships as `1.9.0`.
- **Tailwind content globs** — add `./node_modules/discussing/dist/**/*.{js,mjs}` to both `tailwind.config.js` and `tailwind.config.ts`. The package's utility classes were previously **not scanned**, so any class it used that wasn't also present elsewhere in the blog was silently dropped — a big part of why the comments looked half-styled.

## Status

✅ **Unblocked** — `discussing@1.9.0` is live on npm and verified to contain the redesign (`comment-format` util present, old quote-bar layout gone). The lockfile resolves the real published package.

## Testing

- Verified live against a real V2EX thread on `localhost:3000`: avatar-gutter layout, relative timestamps, collapsed `@mention` gaps, and the "Show N more comments" disclosure all render correctly.
- `npm install` resolves `discussing@1.9.0` from the registry with integrity.