### PR TITLE
fix(translate): raise /api/translate timeout to 60s (fixes 504 on post bodies)

### DIFF
--- a/app/api/translate/route.ts
+++ b/app/api/translate/route.ts
@@ -1,6 +1,13 @@
 import { translateMarkdown, translateText, shouldTranslate } from '@/lib/translate'
 import { NextRequest, NextResponse } from 'next/server'
 
+// Translating a full blog post is a single DeepSeek call that routinely runs
+// well past Vercel's ~10s default, returning 504 for anything but short text
+// (e.g. titles). Give the request room to finish. 60s is the Hobby ceiling;
+// Pro allows up to 300.
+export const maxDuration = 60
+export const runtime = 'nodejs'
+
 export interface TranslateRequestBody {
   text: string
   targetLocale: string


### PR DESCRIPTION
## Problem

On production, blog **titles** translate but post **bodies** fail with `504` (`[useTranslation] Error: Translation failed (504)`).

Root cause: `app/api/translate/route.ts` sets no `maxDuration`, so it runs on Vercel's ~10s default. A full-post translation is a single DeepSeek call that exceeds 10s, so Vercel kills the function → 504. Short strings (titles) return in ~2s and are unaffected.

Reproduced against production: a 3,313-char body → `HTTP 504` at **10.75s** (gateway cutoff); the same short title succeeds.

## Fix

```ts
export const maxDuration = 60   // Hobby ceiling; Pro allows up to 300
export const runtime = 'nodejs'
```

Gives the DeepSeek request room to finish. One route, two lines.

## Verification
- ✅ `next build` compiles; `/api/translate` present in the route manifest.

## Known follow-up (not in this PR)
Vercel's serverless filesystem is read-only outside `/tmp`, so the engine's `data/translations/` file cache silently no-ops — every visit re-translates (slow first paint + repeated API cost). A durable fix is a serverless-safe cache (Vercel KV / Upstash) or translate-at-publish. Happy to follow up if wanted.