### PR TITLE
fix: translate memo content on index page via StatusCard

### DIFF
--- a/components/StatusCard.tsx
+++ b/components/StatusCard.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image'
 import Link from 'next/link'
 import { Memo } from '@/lib/types'
 import { formatMemoDate, processMemoForPreview } from '@/lib/utils'
+import { StatusCardContent } from './StatusCardContent'
 
 const SocialLink = ({ href, title, icon, label, textClassName = '' }: {
   href: string
@@ -121,16 +122,7 @@ export const StatusCard = ({
             </div>
             {memo && (() => {
               const { processedContent, hasImages } = processMemoForPreview(memo.content);
-              return (
-                <div className='text-base leading-relaxed break-words'>
-                  <p>{processedContent}</p>
-                  {hasImages && (
-                    <p className='text-xs text-gray-400 mt-2 italic'>
-                      Contains images - view in &quot;more&quot; →
-                    </p>
-                  )}
-                </div>
-              );
+              return <StatusCardContent content={processedContent} hasImages={hasImages} />;
             })()}
           </div>
         </CardContent>

--- a/components/StatusCardContent.tsx
+++ b/components/StatusCardContent.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import { useTranslation } from '@/hooks/useTranslation'
+
+interface StatusCardContentProps {
+  content: string
+  hasImages: boolean
+}
+
+export function StatusCardContent({ content, hasImages }: StatusCardContentProps) {
+  const {
+    translatedText,
+    isTranslating,
+    toggleOriginal,
+    showOriginal,
+    actuallyTranslated,
+  } = useTranslation(content, false, `status-memo`)
+
+  return (
+    <>
+      <div className='text-base leading-relaxed break-words'>
+        <p>{translatedText}</p>
+        {isTranslating && (
+          <span className='text-xs text-gray-400 animate-pulse'>translating...</span>
+        )}
+        {hasImages && (
+          <p className='text-xs text-gray-400 mt-2 italic'>
+            Contains images - view in &quot;more&quot; →
+          </p>
+        )}
+      </div>
+      {actuallyTranslated && (
+        <div className='flex items-center gap-2 mt-1'>
+          <button
+            onClick={toggleOriginal}
+            className='text-xs text-gray-400 hover:text-gray-600 underline underline-offset-2 transition-colors'
+          >
+            {showOriginal ? 'Show translation' : 'Show original'}
+          </button>
+          {!showOriginal && (
+            <span className='inline-flex items-center gap-1 text-xs text-green-400'>
+              <span className='w-1.5 h-1.5 rounded-full bg-green-400' />
+              Translated
+            </span>
+          )}
+        </div>
+      )}
+    </>
+  )
+}

--- a/scripts/verify-deepseek.mjs
+++ b/scripts/verify-deepseek.mjs
@@ -1,0 +1,39 @@
+// Throwaway live check for the DeepSeek translation contract used by
+// lib/translate.ts. Run with your key available in the environment:
+//   ! DEEPSEEK_API_KEY=sk-... node scripts/verify-deepseek.mjs
+// or, if your shell already exports it:
+//   ! node scripts/verify-deepseek.mjs
+const apiKey = process.env.DEEPSEEK_API_KEY
+if (!apiKey) {
+  console.error('DEEPSEEK_API_KEY is not set in this shell.')
+  process.exit(1)
+}
+
+const sample = '## 今天的随想\n\n我在用 `Next.js` 重写博客，顺手加了自动翻译功能。'
+const system =
+  'You are a professional translator. Translate the user\'s Markdown content into English. ' +
+  'Translate prose only. Preserve all Markdown structure exactly: headings, lists, links, ' +
+  'inline code, and fenced code blocks (do not translate code). Output only the translated Markdown.'
+
+const res = await fetch('https://api.deepseek.com/chat/completions', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${apiKey}` },
+  body: JSON.stringify({
+    model: 'deepseek-chat',
+    temperature: 1.3,
+    messages: [
+      { role: 'system', content: system },
+      { role: 'user', content: sample },
+    ],
+  }),
+})
+
+console.log('HTTP status:', res.status, res.statusText)
+if (!res.ok) {
+  console.error('Body:', await res.text())
+  process.exit(1)
+}
+const data = await res.json()
+console.log('\n--- ORIGINAL ---\n' + sample)
+console.log('\n--- TRANSLATED ---\n' + data?.choices?.[0]?.message?.content)
+console.log('\nOK: DeepSeek returned a translation in the expected shape.')


### PR DESCRIPTION
## Summary

The `StatusCard` component on the homepage renders the latest memo but was never connected to the `useTranslation` hook — the memo text always appeared in the original Chinese.

## Changes

| File | Purpose |
|------|---------|
| `components/StatusCardContent.tsx` | New client component wrapping memo text with `useTranslation` + indicator/toggle |
| `components/StatusCard.tsx` | Replaced raw `<p>{processedContent}</p>` with `<StatusCardContent>` |
| `scripts/verify-deepseek.mjs` | Helper script from earlier refactoring — handy for manual API testing |

## Verification

- ✅ Build compiles
- ✅ Lint clean
- ✅ Index page memo now shows translation indicator + toggle