### PR TITLE
perf(blog): fetch blog post directly instead of loading all posts

### DIFF
--- a/app/blog/[id]/page.tsx
+++ b/app/blog/[id]/page.tsx
@@ -9,8 +9,8 @@ export const revalidate = process.env.NODE_ENV === 'development' ? 0 : 60;
 export default async function Page({ params }: { params: { id: string } }) {
   const session = await getServerSession(authOptions);
   const client = createSmartClient(session?.accessToken)
-  const posts = await client.getBlogPosts()
-  const post = posts.find((p) => p.id === decodeURIComponent(params.id))
+  // Fetch the single post directly instead of loading every post and .find()-ing.
+  const post = await client.getBlogPost(decodeURIComponent(params.id) + '.md')
 
   if (!post) {
     return <div>Post not found</div>


### PR DESCRIPTION
## What
The blog detail page (`app/blog/[id]/page.tsx`) fetched **every** post via `getBlogPosts()` and then `.find()`'d the one it needed. Replaced with a direct `getBlogPost(id + '.md')` fetch.

## Why
Removes an N+1 that scales with the total number of posts — each blog detail view was pulling the whole corpus just to render one post.

## Verification
- ✅ `next lint` clean, `tsc --noEmit` exit 0, `next build` compiles
- `SmartClient.getBlogPost(name)` returns `BlogPost | undefined`; the existing `if (!post)` guard handles the not-found case (works for both null/undefined)

## Supersedes
Reimplements #68 cleanly on current `main` (that branch was stale). Closing #68 in favor of this.