### PR TITLE
refactor(content): centralize data/ layout in a content-path registry

### DIFF
--- a/__tests__/lib/content/paths.test.ts
+++ b/__tests__/lib/content/paths.test.ts
@@ -1,0 +1,41 @@
+import { CONTENT_ROOT, contentPaths } from '@/lib/content/paths'
+
+describe('contentPaths registry', () => {
+  it('roots everything under CONTENT_ROOT', () => {
+    expect(CONTENT_ROOT).toBe('data')
+    for (const build of Object.values(contentPaths)) {
+      expect((build as (a?: string) => string)('x')).toMatch(/^data(\/|$)/)
+    }
+  })
+
+  it('returns the canonical repo-relative paths', () => {
+    expect(contentPaths.root()).toBe('data')
+    expect(contentPaths.rootKeep()).toBe('data/.gitkeep')
+    expect(contentPaths.blogDir()).toBe('data/blog')
+    expect(contentPaths.blogDirKeep()).toBe('data/blog/.gitkeep')
+    expect(contentPaths.blogManifest()).toBe('data/blog-manifest.json')
+    expect(contentPaths.memos()).toBe('data/memos.json')
+    expect(contentPaths.likes()).toBe('data/likes.json')
+    expect(contentPaths.siteConfig()).toBe('data/site-config.json')
+    expect(contentPaths.highlightsDir()).toBe('data/highlights')
+  })
+
+  it('builds a blog path from a bare slug (no .md) and appends exactly one .md', () => {
+    expect(contentPaths.blogPost('hello-world')).toBe('data/blog/hello-world.md')
+    // slug must not be double-suffixed by the helper
+    expect(contentPaths.blogPost('hello-world')).not.toContain('.md.md')
+  })
+
+  it('builds a blog path from a filename that already has .md', () => {
+    expect(contentPaths.blogFile('hello-world.md')).toBe('data/blog/hello-world.md')
+  })
+
+  it('builds a highlights file path from a slug', () => {
+    expect(contentPaths.highlightsFile('hello-world')).toBe('data/highlights/hello-world.json')
+  })
+
+  it('produces no leading slash (safe to join or concat behind a base URL)', () => {
+    expect(contentPaths.blogPost('x').startsWith('/')).toBe(false)
+    expect(contentPaths.memos().startsWith('/')).toBe(false)
+  })
+})

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -4,6 +4,7 @@ import { parseBlogPostMetadata } from './markdown'
 
 import { Octokit } from '@octokit/rest'
 import { createHybridGitHubClient } from './publicClient'
+import { contentPaths } from './content/paths'
 
 const REPO = 'Cofe'
 
@@ -52,7 +53,7 @@ class GitHubAPIClient {
       const response = await octokit.repos.getContent({
         owner: safeOwner,
         repo: REPO,
-        path: 'data/blog',
+        path: contentPaths.blogDir(),
       })
 
       if (!Array.isArray(response.data)) {
@@ -99,7 +100,7 @@ class GitHubAPIClient {
     const contentResponse = await octokit.repos.getContent({
       owner: safeOwner,
       repo: REPO,
-      path: `data/blog/${name}`,
+      path: contentPaths.blogFile(name),
     })
 
     if ('content' in contentResponse.data) {
@@ -133,7 +134,7 @@ class GitHubAPIClient {
       const response = await octokit.repos.getContent({
         owner: safeOwner,
         repo: REPO,
-        path: 'data/memos.json',
+        path: contentPaths.memos(),
       })
 
       if (Array.isArray(response.data) || !('content' in response.data)) {
@@ -155,7 +156,7 @@ class GitHubAPIClient {
       const response = await octokit.repos.getContent({
         owner: safeOwner,
         repo: REPO,
-        path: 'data/site-config.json',
+        path: contentPaths.siteConfig(),
       })
       if (Array.isArray(response.data) || !('content' in response.data)) {
         return {}
@@ -176,7 +177,7 @@ class GitHubAPIClient {
       const response = await octokit.repos.getContent({
         owner: safeOwner,
         repo: REPO,
-        path: 'data/likes.json',
+        path: contentPaths.likes(),
       })
 
       if (Array.isArray(response.data) || !('content' in response.data)) {
@@ -206,7 +207,7 @@ class GitHubAPIClient {
         const currentFile = await octokit.repos.getContent({
           owner: safeOwner,
           repo: REPO,
-          path: 'data/likes.json',
+          path: contentPaths.likes(),
         })
 
         if (!Array.isArray(currentFile.data) && 'sha' in currentFile.data) {
@@ -220,7 +221,7 @@ class GitHubAPIClient {
       await octokit.repos.createOrUpdateFileContents({
         owner: safeOwner,
         repo: REPO,
-        path: 'data/likes.json',
+        path: contentPaths.likes(),
         message: `Update likes data - ${new Date().toISOString()}`,
         content: Buffer.from(JSON.stringify(likesData, null, 2)).toString('base64'),
         ...(sha && { sha }),

--- a/lib/content/paths.ts
+++ b/lib/content/paths.ts
@@ -1,0 +1,51 @@
+/**
+ * Single source of truth for Cofe's content layout in the repo.
+ *
+ * Every consumer (GitHub API clients, the public raw-URL reader, and the local
+ * dev filesystem client) asks this module for a path instead of hardcoding a
+ * `data/...` literal. That keeps the physical hierarchy in ONE place: change
+ * `CONTENT_ROOT` (or a builder) here and the whole app follows.
+ *
+ * Contract: builders return **repo-relative POSIX paths** with no leading slash
+ * (e.g. `data/blog/my-post.md`). This is the common denominator for all three
+ * consumers:
+ *   - GitHub API clients pass the string straight to octokit.
+ *   - publicClient builds `${baseUrl}/${path}` for raw.githubusercontent.
+ *   - localClient.server joins `process.cwd()` with the string for local reads.
+ *
+ * This module MUST stay import-safe from both client and server components:
+ * no `fs`, no `path`, no `process`. Server-only filesystem joining lives in
+ * localClient.server.ts.
+ */
+
+export const CONTENT_ROOT = 'data'
+
+export const contentPaths = {
+  /** Content root directory. */
+  root: () => CONTENT_ROOT,
+  /** Keep-file that ensures the content root exists on init. */
+  rootKeep: () => `${CONTENT_ROOT}/.gitkeep`,
+
+  /** Blog posts directory. */
+  blogDir: () => `${CONTENT_ROOT}/blog`,
+  /** Keep-file that ensures the blog directory exists on init. */
+  blogDirKeep: () => `${CONTENT_ROOT}/blog/.gitkeep`,
+  /** Blog post from a bare slug (no extension); appends exactly one `.md`. */
+  blogPost: (slug: string) => `${CONTENT_ROOT}/blog/${slug}.md`,
+  /** Blog post from a filename that already carries its `.md` extension. */
+  blogFile: (filename: string) => `${CONTENT_ROOT}/blog/${filename}`,
+  /** Derived index of blog posts. */
+  blogManifest: () => `${CONTENT_ROOT}/blog-manifest.json`,
+
+  /** Memos store. */
+  memos: () => `${CONTENT_ROOT}/memos.json`,
+  /** Likes store. */
+  likes: () => `${CONTENT_ROOT}/likes.json`,
+  /** Site configuration (runtime read/write path; see note in siteConfig.ts). */
+  siteConfig: () => `${CONTENT_ROOT}/site-config.json`,
+
+  /** Highlights directory (one JSON file per post slug). */
+  highlightsDir: () => `${CONTENT_ROOT}/highlights`,
+  /** Highlights file for a given post slug. */
+  highlightsFile: (slug: string) => `${CONTENT_ROOT}/highlights/${slug}.json`,
+} as const

--- a/lib/githubApi.ts
+++ b/lib/githubApi.ts
@@ -1,6 +1,7 @@
 import { Memo, ExternalDiscussion } from './types';
 import { Octokit } from '@octokit/rest';
 import { updateBlogManifest } from './manifestUtils';
+import { contentPaths } from './content/paths';
 import path from 'path';
 import {
   getOctokit,
@@ -108,7 +109,7 @@ async function ensureContentStructure(octokit: Octokit, owner: string, repo: str
       octokit,
       owner,
       repo,
-      'data/.gitkeep',
+      contentPaths.rootKeep(),
       'Initialize content directory',
       ''
     )
@@ -116,7 +117,7 @@ async function ensureContentStructure(octokit: Octokit, owner: string, repo: str
       octokit,
       owner,
       repo,
-      'data/blog/.gitkeep',
+      contentPaths.blogDirKeep(),
       'Initialize blog directory',
       ''
     )
@@ -124,7 +125,7 @@ async function ensureContentStructure(octokit: Octokit, owner: string, repo: str
       octokit,
       owner,
       repo,
-      'data/memos.json',
+      contentPaths.memos(),
       'Initialize memos.json',
       '[]'
     )
@@ -152,7 +153,7 @@ export async function createBlogPost(
   await initializeGitHubStructure(octokit, owner, repo)
 
   const filename = `${title.toLowerCase().replace(/\s+/g, '-')}.md`
-  const path = `data/blog/${filename}`
+  const path = contentPaths.blogFile(filename)
   const date = new Date().toISOString() // Store full ISO string
   const discussionsYaml = formatDiscussions(discussions)
   const locationYaml = location ? `latitude: ${location.latitude || ''}
@@ -209,7 +210,7 @@ export async function createMemo(
       const response = await octokit.repos.getContent({
         owner,
         repo,
-        path: 'data/memos.json',
+        path: contentPaths.memos(),
       })
 
       if (!Array.isArray(response.data) && 'content' in response.data) {
@@ -247,7 +248,7 @@ export async function createMemo(
     const updateParams: UpdateFileParams = {
       owner,
       repo,
-      path: 'data/memos.json',
+      path: contentPaths.memos(),
       message: 'Add new memo',
       content: Buffer.from(JSON.stringify(memos, null, 2)).toString('base64'),
     }
@@ -287,7 +288,7 @@ export async function deleteMemo(id: string, accessToken: string): Promise<void>
     const response = await octokit.repos.getContent({
       owner,
       repo,
-      path: 'data/memos.json',
+      path: contentPaths.memos(),
     })
 
     if (!Array.isArray(response.data) && 'content' in response.data) {
@@ -306,7 +307,7 @@ export async function deleteMemo(id: string, accessToken: string): Promise<void>
     const updateParams: UpdateFileParams = {
       owner,
       repo,
-      path: 'data/memos.json',
+      path: contentPaths.memos(),
       message: 'Delete a memo',
       content: Buffer.from(JSON.stringify(newMemos, null, 2)).toString('base64'),
       sha: existingSha,
@@ -347,7 +348,7 @@ export async function updateMemo(
     const response = await octokit.repos.getContent({
       owner,
       repo,
-      path: 'data/memos.json',
+      path: contentPaths.memos(),
     })
 
     if (!Array.isArray(response.data) && 'content' in response.data) {
@@ -374,7 +375,7 @@ export async function updateMemo(
     const updateParams: UpdateFileParams = {
       owner,
       repo,
-      path: 'data/memos.json',
+      path: contentPaths.memos(),
       message: 'Update memo',
       content: Buffer.from(JSON.stringify(memos, null, 2)).toString('base64'),
       sha: existingSha,
@@ -402,7 +403,7 @@ export async function deleteBlogPost(id: string, accessToken: string): Promise<v
     // Decode the ID and create the file path
     const decodedId = decodeURIComponent(id)
     const filename = `${decodedId}.md`
-    const path = `data/blog/${filename}`
+    const path = contentPaths.blogFile(filename)
 
     console.log(`Attempting to delete file: ${path}`)
 
@@ -461,7 +462,7 @@ export async function updateBlogPost(
       octokit,
       owner,
       repo,
-      `data/blog/${id}.md`
+      contentPaths.blogPost(id)
     )
     const dateMatch = existingContent.match(/date:\s*(.+)/)
     const date = dateMatch ? dateMatch[1] : new Date().toISOString()
@@ -490,7 +491,7 @@ ${content}`
       octokit,
       owner,
       repo,
-      `data/blog/${id}.md`,
+      contentPaths.blogPost(id),
       'Update blog post',
       updatedContent,
       sha

--- a/lib/highlights/highlightsRepo.ts
+++ b/lib/highlights/highlightsRepo.ts
@@ -28,9 +28,9 @@ import {
   PostHighlightsSchema,
   emptyPostHighlights,
 } from './schema'
+import { contentPaths } from '../content/paths'
 
 const REPO = 'Cofe'
-const FILE_DIR = 'data/highlights'
 const CACHE_TTL_MS = 30_000
 const SAVE_RETRY_LIMIT = 3
 const MAX_POST_ID_LENGTH = 200
@@ -69,7 +69,7 @@ export function clearHighlightsCache(): void {
 }
 
 function pathFor(postId: string): string {
-  return `${FILE_DIR}/${postId}.json`
+  return contentPaths.highlightsFile(postId)
 }
 
 function assertSafePostId(postId: string): void {
@@ -123,7 +123,7 @@ export class LocalFsHighlightsRepo implements HighlightsRepo {
   constructor(private rootDir: string) {}
 
   private absPath(postId: string): string {
-    return path.join(this.rootDir, FILE_DIR, `${postId}.json`)
+    return path.join(this.rootDir, contentPaths.highlightsFile(postId))
   }
 
   async load(postId: string): Promise<LoadedHighlights> {

--- a/lib/localClient.server.ts
+++ b/lib/localClient.server.ts
@@ -3,18 +3,24 @@ import path from 'path'
 import type { BlogPost, Memo } from './types'
 import { LikesDatabase } from './likeUtils'
 import { parseBlogPostMetadata } from './markdown'
+import { contentPaths } from './content/paths'
 
 /**
  * Local file system client for development (server-side only)
  * Reads data from local data/ directory instead of GitHub
  */
 export class LocalFileSystemClient {
+  /** Resolve a repo-relative content path (from contentPaths) to an absolute local path. */
+  private abs(repoPath: string): string {
+    return path.join(process.cwd(), repoPath)
+  }
+
   private get dataDir() {
-    return path.join(process.cwd(), 'data')
+    return this.abs(contentPaths.root())
   }
 
   private get blogDir() {
-    return path.join(this.dataDir, 'blog')
+    return this.abs(contentPaths.blogDir())
   }
   /**
    * Get all blog posts from local data/blog directory
@@ -97,7 +103,7 @@ export class LocalFileSystemClient {
    */
   async getMemos(): Promise<Memo[]> {
     try {
-      const memosPath = path.join(this.dataDir, 'memos.json')
+      const memosPath = this.abs(contentPaths.memos())
       
       if (!fs.existsSync(memosPath)) {
         console.log('memos.json not found, returning empty array')
@@ -119,7 +125,7 @@ export class LocalFileSystemClient {
    */
   async getLinks(): Promise<Record<string, string>> {
     try {
-      const configPath = path.join(this.dataDir, 'site-config.json')
+      const configPath = this.abs(contentPaths.siteConfig())
       
       if (!fs.existsSync(configPath)) {
         return {}
@@ -140,7 +146,7 @@ export class LocalFileSystemClient {
    */
   async getLikes(): Promise<LikesDatabase> {
     try {
-      const likesPath = path.join(this.dataDir, 'likes.json')
+      const likesPath = this.abs(contentPaths.likes())
       
       if (!fs.existsSync(likesPath)) {
         console.log('likes.json not found, returning empty object')
@@ -162,7 +168,7 @@ export class LocalFileSystemClient {
    */
   async updateLikes(likesData: LikesDatabase): Promise<void> {
     try {
-      const likesPath = path.join(this.dataDir, 'likes.json')
+      const likesPath = this.abs(contentPaths.likes())
       const content = JSON.stringify(likesData, null, 2)
       fs.writeFileSync(likesPath, content, 'utf-8')
       console.log('Updated local likes data')
@@ -180,7 +186,7 @@ export class LocalFileSystemClient {
       const memos = await this.getMemos()
       const updatedMemos = [memo, ...memos]
       
-      const memosPath = path.join(this.dataDir, 'memos.json')
+      const memosPath = this.abs(contentPaths.memos())
       const content = JSON.stringify(updatedMemos, null, 2)
       fs.writeFileSync(memosPath, content, 'utf-8')
       

--- a/lib/manifestUtils.ts
+++ b/lib/manifestUtils.ts
@@ -1,4 +1,5 @@
 import { Octokit } from '@octokit/rest'
+import { contentPaths } from './content/paths'
 
 /**
  * Generate and update the blog manifest file based on published blog posts
@@ -12,7 +13,7 @@ export async function updateBlogManifest(accessToken: string, owner: string, rep
     const { data: files } = await octokit.repos.getContent({
       owner,
       repo,
-      path: 'data/blog',
+      path: contentPaths.blogDir(),
     })
     
     if (!Array.isArray(files)) {
@@ -41,7 +42,7 @@ export async function updateBlogManifest(accessToken: string, owner: string, rep
       const { data: currentManifest } = await octokit.repos.getContent({
         owner,
         repo,
-        path: 'data/blog-manifest.json',
+        path: contentPaths.blogManifest(),
       })
       
       if (!Array.isArray(currentManifest) && 'sha' in currentManifest) {
@@ -56,7 +57,7 @@ export async function updateBlogManifest(accessToken: string, owner: string, rep
     await octokit.repos.createOrUpdateFileContents({
       owner,
       repo,
-      path: 'data/blog-manifest.json',
+      path: contentPaths.blogManifest(),
       message: 'Update blog manifest',
       content: Buffer.from(JSON.stringify(manifest, null, 2)).toString('base64'),
       sha: currentSha, // Required for updates, undefined for creates

--- a/lib/publicClient.ts
+++ b/lib/publicClient.ts
@@ -2,6 +2,7 @@ import { BlogPost, Memo } from './types'
 import { createGitHubAPIClient } from './client'
 import { LikesDatabase } from './likeUtils'
 import { parseBlogPostMetadata } from './markdown'
+import { contentPaths } from './content/paths'
 
 const REPO = 'Cofe'
 
@@ -36,7 +37,7 @@ export class PublicGitHubClient {
     try {
       // Try to fetch a blog manifest file if it exists
       try {
-        const manifestResponse = await fetch(`${this.baseUrl}/data/blog-manifest.json`)
+        const manifestResponse = await fetch(`${this.baseUrl}/${contentPaths.blogManifest()}`)
         if (manifestResponse.ok) {
           const manifest = await manifestResponse.json()
           // Handle both legacy and new manifest formats
@@ -71,7 +72,7 @@ export class PublicGitHubClient {
    */
   async getBlogPost(filename: string): Promise<BlogPost | null> {
     try {
-      const response = await fetch(`${this.baseUrl}/data/blog/${filename}`)
+      const response = await fetch(`${this.baseUrl}/${contentPaths.blogFile(filename)}`)
       
       if (!response.ok) {
         if (response.status === 404) {
@@ -111,7 +112,7 @@ export class PublicGitHubClient {
    */
   async getMemos(): Promise<Memo[]> {
     try {
-      const response = await fetch(`${this.baseUrl}/data/memos.json`)
+      const response = await fetch(`${this.baseUrl}/${contentPaths.memos()}`)
       
       if (!response.ok) {
         if (response.status === 404) {
@@ -134,7 +135,7 @@ export class PublicGitHubClient {
    */
   async getLinks(): Promise<Record<string, string>> {
     try {
-      const response = await fetch(`${this.baseUrl}/data/site-config.json`)
+      const response = await fetch(`${this.baseUrl}/${contentPaths.siteConfig()}`)
       
       if (!response.ok) {
         if (response.status === 404) {
@@ -156,7 +157,7 @@ export class PublicGitHubClient {
    */
   async getLikes(): Promise<LikesDatabase> {
     try {
-      const response = await fetch(`${this.baseUrl}/data/likes.json`)
+      const response = await fetch(`${this.baseUrl}/${contentPaths.likes()}`)
       
       if (!response.ok) {
         if (response.status === 404) {

--- a/lib/siteConfig.ts
+++ b/lib/siteConfig.ts
@@ -1,3 +1,7 @@
+// Build-time static import: the path must be a literal, so it cannot go through
+// contentPaths. The runtime read/write source of truth is contentPaths.siteConfig()
+// (used by client.ts / publicClient.ts / localClient.server.ts). Keep this literal
+// in sync with contentPaths.siteConfig() if the content layout ever moves.
 import siteConfig from '@/data/site-config.json'
 import { headers } from 'next/headers'
 

--- a/lib/smartClient.ts
+++ b/lib/smartClient.ts
@@ -1,5 +1,6 @@
 import { createPublicGitHubClient } from './publicClient'
 import { createGitHubAPIClient } from './client'
+import { contentPaths } from './content/paths'
 import type { BlogPost, Memo } from './types'
 import type { LikesDatabase } from './likeUtils'
 
@@ -155,14 +156,14 @@ export class SmartClient {
         const currentFile = await octokit.repos.getContent({
           owner,
           repo: 'Cofe',
-          path: 'data/memos.json',
+          path: contentPaths.memos(),
         })
 
         if (!Array.isArray(currentFile.data) && 'sha' in currentFile.data) {
           await octokit.repos.createOrUpdateFileContents({
             owner,
             repo: 'Cofe',
-            path: 'data/memos.json',
+            path: contentPaths.memos(),
             message: `Add new memo: ${memo.id}`,
             content: Buffer.from(JSON.stringify(updatedMemos, null, 2)).toString('base64'),
             sha: currentFile.data.sha,
@@ -173,7 +174,7 @@ export class SmartClient {
           await octokit.repos.createOrUpdateFileContents({
             owner,
             repo: 'Cofe',
-            path: 'data/memos.json',
+            path: contentPaths.memos(),
             message: `Create memos.json with first memo: ${memo.id}`,
             content: Buffer.from(JSON.stringify(updatedMemos, null, 2)).toString('base64'),
           })


### PR DESCRIPTION
## What

Adds `lib/content/paths.ts` — one module that owns Cofe's content hierarchy — and reroutes every consumer through it instead of hardcoding `data/...` string literals.

This is **Step 1** of separating content from code (per `.plans/cofe-content-path-registry.md`): the prerequisite that makes any later move (relocating `data/`, or splitting content into its own repo) a one-file change instead of an 8-file edit.

## Why

`data/`, `data/blog/`, `data/memos.json` etc. were hardcoded across ~7 files as the boundary between engine and content, in three different flavors:
- GitHub API paths (`githubApi`, `client`, `smartClient`, `manifestUtils`, `highlightsRepo`)
- raw.githubusercontent URLs (`publicClient`)
- local FS paths (`localClient.server`)

One registry now returns **repo-relative POSIX paths** (`data/blog/<slug>.md`), the common denominator for all three.

## Guarantees

**Pure refactor — no behavior change, no URL change.** `CONTENT_ROOT` stays `'data'`, so every API path, raw URL, and FS path is byte-identical to before. Live `raw.githubusercontent.com/.../data/blog/...` permalinks and the CMS storage contract are untouched.

## The one documented exception

`lib/siteConfig.ts` keeps its static `import ... from '@/data/site-config.json'` — an ES import specifier must be a literal, so it can't go through a runtime function. Commented with a pointer to `contentPaths.siteConfig()` (the runtime source of truth used everywhere else).

## Verification

- ✅ grep guard: no `data/` code literals remain outside the registry (only the documented static import + human-readable doc comments)
- ✅ `next lint` clean
- ✅ `tsc --noEmit` exit 0
- ✅ `jest` 148/148 (142 prior + 6 new registry tests)
- ✅ `next build` compiles, 17/17 pages

## Out of scope (Step 2+, separate PRs)

- Physically moving `data/` → `content/` (needs a raw-URL redirect for old permalinks)
- Splitting content into its own repo (`CONTENT_REPO` env) — this PR is its prerequisite
- Converting `memos.json` monolith → one-file-per-memo