### PR TITLE
release: v0.1.1 + fix OIDC publish (pin npm@11)

### DIFF
--- a/.github/workflows/cici_release.yml
+++ b/.github/workflows/cici_release.yml
@@ -37,7 +37,7 @@ jobs:
 
       # Trusted publishing (OIDC) needs npm >= 11.5.1; Node 20 ships npm 10.x.
       - name: Upgrade npm (OIDC support)
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - name: Install deps
         run: npm ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cici",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cici",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@auth/core": "^0.34.2",
         "@giscus/react": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cici",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": false,
   "description": "Cofe — a git-backed blog CMS. Run `npx cici --dir <dir>` or `--repo <owner/name>` to serve and edit your posts.",
   "bin": {


### PR DESCRIPTION
Fixes the failed `v0.1.0` publish and bumps to `0.1.1`.

## Why the publish failed
The release workflow's `npm install -g npm@latest` step pulled **npm@12**, which requires **Node ≥ 22.22.2**; the workflow runs **Node 20** → `EBADENGINE`, dying before publish.

## Changes
- `.github/workflows/cici_release.yml`: `npm@latest` → **`npm@11`** (still supports OIDC trusted publishing, ≥ 11.5.1; compatible with Node 20).
- `package.json` + `package-lock.json`: `0.1.0` → **`0.1.1`**.

## After merge
```bash
git checkout main && git pull
git tag v0.1.1 && git push origin v0.1.1
```
The tag triggers the (now-fixed) workflow → `npm publish --provenance` via the OIDC trusted publisher → `cici@0.1.1`. Then `npx cici --dir ~/blog`.

Nothing was published at 0.1.0 (the run failed early), so 0.1.1 is a clean first release.