### PR TITLE
ci: fix OIDC publish (drop setup-node registry-url → E404)

### DIFF
--- a/.github/workflows/cici_release.yml
+++ b/.github/workflows/cici_release.yml
@@ -30,10 +30,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # NOTE: intentionally NO `registry-url`. setup-node's registry-url writes an
+      # .npmrc `_authToken=${NODE_AUTH_TOKEN}` line (with a placeholder token when
+      # none is provided), which makes npm attempt token auth and skip OIDC → E404.
+      # Publishing to the default registry (registry.npmjs.org) with no token lets
+      # npm use the OIDC trusted publisher.
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-          registry-url: 'https://registry.npmjs.org'
 
       # Trusted publishing (OIDC) needs npm >= 11.5.1; Node 20 ships npm 10.x.
       - name: Upgrade npm (OIDC support)


### PR DESCRIPTION
## Root cause of the `E404` publish failures
`actions/setup-node` with `registry-url` writes `~/.npmrc`:
```
//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
```
and, when no token is supplied, sets `NODE_AUTH_TOKEN` to the literal placeholder `XXXXX-XXXXX-XXXXX-XXXXX`. So `npm publish` authenticates with that **bogus token instead of OIDC**, and the registry rejects it:
```
npm error 404 PUT https://registry.npmjs.org/cici — 'cici@0.1.1' ... or you do not have permission
```
(npm returns 404, not 403, to avoid leaking package existence.) OIDC never engages because a token is "configured."

## Fix
Remove `registry-url` from `setup-node`. With no `_authToken` line and no token env, `npm publish --provenance` falls through to **OIDC trusted publishing** against the default registry (registry.npmjs.org). npm 11 + `id-token: write` (both already present) do the rest.

## After merge
Re-run the release: Actions → the `v0.1.1` run → **Re-run failed jobs** (or push a fresh tag). No version bump needed — nothing published yet.

Requires the Trusted Publisher on `cici` to be saved (GitHub Actions / metrue / **cici** / **cici_release.yml** / Allow `npm publish`). This fix forces the OIDC path, so if the publisher is set correctly it'll now succeed; if it still errors, the message should finally point at the publisher config rather than a token 404.