### PR TITLE
ci: Node 22 for npm trusted publishing (fixes ENEEDAUTH)

### DIFF
--- a/.github/workflows/cici_release.yml
+++ b/.github/workflows/cici_release.yml
@@ -3,14 +3,18 @@ name: Release (npm)
 # Publishes the `cici` package (the cici CLI) to npm when a version tag is pushed.
 #
 # Auth: npm Trusted Publisher (OIDC) — NO NPM_TOKEN secret. Set up the trust on
-# npmjs.com → package `cici` → Settings → Trusted Publisher:
-#   Publisher: GitHub Actions | Org/user: metrue | Repository: cici
-#   Workflow filename: cici_release.yml | Allowed actions: Allow npm publish
+# npmjs.com → package `cici` → Settings → Trusted publishing → GitHub Actions.
+# ALL FIELDS ARE CASE-SENSITIVE AND MUST BE EXACT:
+#   Organization or user: metrue
+#   Repository:           cici              (repo NAME only, not metrue/cici)
+#   Workflow filename:    cici_release.yml  (basename, underscore not hyphen)
+#   Environment name:     (blank)
+#   Allowed actions:      npm publish
 # The OIDC id-token (permissions.id-token: write) is exchanged for a short-lived
 # publish credential at publish time.
 #
-# To activate: move this file to `.github/workflows/cici_release.yml`
-# (requires a token with GitHub `workflow` scope).
+# Requirements (docs.npmjs.com/trusted-publishers): npm CLI >= 11.5.1 AND
+# Node >= 22.14.0. Node 22 satisfies the Node floor; npm is upgraded below.
 #
 # Release flow:
 #   1. bump "version" in package.json (must be > the current npm version)
@@ -37,9 +41,9 @@ jobs:
       # npm use the OIDC trusted publisher.
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22' # trusted publishing requires Node >= 22.14.0
 
-      # Trusted publishing (OIDC) needs npm >= 11.5.1; Node 20 ships npm 10.x.
+      # Node 22 ships npm 10.x; trusted publishing needs npm >= 11.5.1.
       - name: Upgrade npm (OIDC support)
         run: npm install -g npm@11
 


### PR DESCRIPTION
Keeps tokenless **OIDC trusted publishing** (no NPM_TOKEN). Fixes the CI-side root cause of the failed `v0.1.1` release runs.

## Root cause
npm's [trusted-publisher docs](https://docs.npmjs.com/trusted-publishers) require **npm CLI ≥ 11.5.1 AND Node ≥ 22.14.0**. Our workflow ran on **Node 20**, so the npm CLI's OIDC path never activated → publish fell back to no credential → `ENEEDAUTH`.

## Change
`.github/workflows/cici_release.yml`: `node-version` `'20'` → `'22'`. npm is still upgraded to 11 (≥ 11.5.1). Recorded the exact, case-sensitive Trusted Publisher field values in the header comment.

## Also required on npmjs.com (I can't set this)
The Trusted Publisher registration on package `cici` must match **exactly** (case-sensitive):
- Organization or user: `metrue`
- Repository: `cici`  ← currently `cic` (typo)
- Workflow filename: `cici_release.yml`  ← currently `cici-release.yml` (hyphen; must be underscore)
- Environment name: blank
- Allowed actions: `npm publish`

## Then
Merge this → re-run the `v0.1.1` release workflow → publishes `cici@0.1.1` via OIDC.

Supersedes #99 (the NPM_TOKEN fallback), which should be closed — we're staying on trusted publishing.