### PR TITLE
fix: add repository.url for npm provenance (E422)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,15 @@
   "name": "cici",
   "version": "0.1.1",
   "private": false,
-  "description": "Cofe — a git-backed blog CMS. Run `npx cici --dir <dir>` or `--repo <owner/name>` to serve and edit your posts.",
+  "description": "cici — a git-backed blog CMS. Run `npx cici --dir <dir>` or `--repo <owner/name>` to serve and edit your posts.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/metrue/cici.git"
+  },
+  "homepage": "https://github.com/metrue/cici#readme",
+  "bugs": {
+    "url": "https://github.com/metrue/cici/issues"
+  },
   "bin": {
     "cici": "bin/cici.js"
   },


### PR DESCRIPTION
OIDC trusted publishing now authenticates (the `cici_release.yml` filename fix worked). The publish then failed provenance verification:

```
E422 ... package.json: "repository.url" is "", expected to match "https://github.com/metrue/cici"
```

`npm publish --provenance` validates the sigstore bundle's repo against `package.json` `repository.url`, which was missing. Adds `repository`/`homepage`/`bugs` → `metrue/cici`, and fixes the leftover `Cofe` brand string in `description`.

Merge → re-push `v0.1.1` tag → publishes `cici@0.1.1`.