### PR TITLE
release: v0.2.0 (post tooling/content split)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cici",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cici",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "dependencies": {
         "@auth/core": "^0.34.2",
         "@giscus/react": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cici",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "private": false,
   "description": "cici — a git-backed blog CMS (pure tooling; your posts live in a separate content repo). Run `npx cici --dir <dir>` or `--repo <owner/name>` to serve/edit, or `cici build` / `cici start` to deploy.",
   "repository": {


### PR DESCRIPTION
Bumps `cici` to **0.2.0** — first release after the split (#102).

## What's in 0.2.0
- No bundled blog content (ships `sample-content/` fixture instead)
- Private-repo authenticated reads (`GitHubProvider.getSiteConfig` + provider reads work with `CICI_TOKEN`)
- New CLI: `cici build` and `cici start`

## Release
Merge → tag `v0.2.0` on the merged commit → the OIDC trusted-publisher workflow publishes `cici@0.2.0`.